### PR TITLE
テスト時にclojure.specのチェックを有効化

### DIFF
--- a/fp-in-clojure/test/fp_in_clojure/exercises/getting_started/my_program_test.clj
+++ b/fp-in-clojure/test/fp_in_clojure/exercises/getting_started/my_program_test.clj
@@ -1,6 +1,7 @@
 (ns fp-in-clojure.exercises.getting-started.my-program-test
   (:require
    [clojure.spec.alpha :as s]
+   [clojure.test :as t]
    [clojure.test.check.clojure-test :as tc]
    [clojure.test.check.properties :as prop]
    ;; 解答例
@@ -8,7 +9,11 @@
    ;; ref. https://clojure.org/guides/weird_characters#_discard
    #_[fp-in-clojure.answers.getting-started.my-program :as sut]
    [fp-in-clojure.exercises.common :as common]
-   [fp-in-clojure.exercises.getting-started.my-program :as sut]))
+   [fp-in-clojure.exercises.getting-started.my-program :as sut]
+   [fp-in-clojure.test-helper :as test-helper]))
+
+(t/use-fixtures
+  :once test-helper/instrument-specs)
 
 ;; NOTE: test.checkによるプロパティベーステスト(PBT)のテストケース
 ;; ref. https://github.com/clojure/test.check

--- a/fp-in-clojure/test/fp_in_clojure/exercises/getting_started/polymorphic_functions_test.clj
+++ b/fp-in-clojure/test/fp_in_clojure/exercises/getting_started/polymorphic_functions_test.clj
@@ -2,13 +2,18 @@
   (:require
    [clojure.spec.alpha :as s]
    [clojure.spec.gen.alpha :as sgen]
+   [clojure.test :as t]
    [clojure.test.check.clojure-test :as tc]
    [clojure.test.check.generators :as gen]
    [clojure.test.check.properties :as prop]
    ;; 解答例
    #_[fp-in-clojure.answers.getting-started.polymorphic-functions :as sut]
    [fp-in-clojure.exercises.common :as common]
-   [fp-in-clojure.exercises.getting-started.polymorphic-functions :as sut]))
+   [fp-in-clojure.exercises.getting-started.polymorphic-functions :as sut]
+   [fp-in-clojure.test-helper :as test-helper]))
+
+(t/use-fixtures
+  :once test-helper/instrument-specs)
 
 (def ^:private mul-curry
   (sut/curry *'))

--- a/fp-in-clojure/test/fp_in_clojure/test_helper.clj
+++ b/fp-in-clojure/test/fp_in_clojure/test_helper.clj
@@ -1,0 +1,32 @@
+(ns fp-in-clojure.test-helper
+  (:require
+   [clojure.spec.test.alpha :as stest]
+   [clojure.string :as str]))
+
+(defn- test-ns->sut-ns-sym [test-ns]
+  (let [test-ns-name (-> test-ns ns-name str)]
+    (when (str/ends-with? test-ns-name "-test")
+      (-> test-ns-name
+          (str/replace #"-test$" "")
+          symbol))))
+
+(defn- instrument-ns [ns-sym]
+  (->> (stest/instrumentable-syms)
+       (filter #(= (namespace %) (name ns-sym)))
+       stest/instrument))
+
+(defn- unstrument-ns [ns-sym]
+  (->> (stest/instrumentable-syms)
+       (filter #(= (namespace %) (name ns-sym)))
+       stest/unstrument))
+
+;; fixtures
+
+(defn instrument-specs [f]
+  (if-let [sut-ns-sym (test-ns->sut-ns-sym *ns*)]
+    (do (instrument-ns sut-ns-sym)
+        (try
+          (f)
+          (finally
+            (unstrument-ns sut-ns-sym))))
+    (f)))


### PR DESCRIPTION
# 既存言語の内容を改善する場合

## 変更している内容とその理由

<!--
今回のPRの概要とその理由を簡潔に説明してください。
段階的に改善する場合には後続の対応の見通しも教えてください。
-->

Clojure版のテストコードでclojure.specのチェックを有効化した。
これにより、ソースコード側で定義している `fdef` のspecがテスト実行時に検証され、specがより有効活用されるようになる。

## チェックリスト

- [x] 変更内容に合理的な理由があることを上記セクションで説明した
- [x] [CONTRIBUTING.md](https://github.com/fp-matsuri/fp-in-scala-exercises/blob/main/CONTRIBUTING.md)の問題作成方針に沿って作成した
- [x] 不要な(自動生成)ファイルが含まれないように適切に `.gitignore` されている
- [x] [テストコードがある場合] `exercises` 配下に `answers` 相当の解答例を反映するとすべてのテストケースがパスする
    - ℹ️ テストコードで指定しているテスト対象モジュールを `exercises` から `answers` のものに切り替えて試すのが楽かも
- [x] [リンター/フォーマッターがある場合] `exercises` 配下の未実装箇所周辺(演習問題のための未使用変数/関数など)を除いてすべてのチェックがパスする
