### PR TITLE
specのチェック有効化のためのヘルパー関数を修正

### DIFF
--- a/fp-in-clojure/test/fp_in_clojure/exercises/getting_started/my_program_test.clj
+++ b/fp-in-clojure/test/fp_in_clojure/exercises/getting_started/my_program_test.clj
@@ -13,7 +13,7 @@
    [fp-in-clojure.test-helper :as test-helper]))
 
 (t/use-fixtures
-  :once test-helper/instrument-specs)
+  :once (test-helper/instrument-specs *ns*))
 
 ;; NOTE: test.checkによるプロパティベーステスト(PBT)のテストケース
 ;; ref. https://github.com/clojure/test.check

--- a/fp-in-clojure/test/fp_in_clojure/exercises/getting_started/polymorphic_functions_test.clj
+++ b/fp-in-clojure/test/fp_in_clojure/exercises/getting_started/polymorphic_functions_test.clj
@@ -13,7 +13,7 @@
    [fp-in-clojure.test-helper :as test-helper]))
 
 (t/use-fixtures
-  :once test-helper/instrument-specs)
+  :once (test-helper/instrument-specs *ns*))
 
 (def ^:private mul-curry
   (sut/curry *'))

--- a/fp-in-clojure/test/fp_in_clojure/test_helper.clj
+++ b/fp-in-clojure/test/fp_in_clojure/test_helper.clj
@@ -22,11 +22,12 @@
 
 ;; fixtures
 
-(defn instrument-specs [f]
-  (if-let [sut-ns-sym (test-ns->sut-ns-sym *ns*)]
-    (do (instrument-ns sut-ns-sym)
-        (try
-          (f)
-          (finally
-            (unstrument-ns sut-ns-sym))))
-    (f)))
+(defn instrument-specs [test-ns]
+  (fn [f]
+    (if-let [sut-ns-sym (test-ns->sut-ns-sym test-ns)]
+      (do (instrument-ns sut-ns-sym)
+          (try
+            (f)
+            (finally
+              (unstrument-ns sut-ns-sym))))
+      (f))))


### PR DESCRIPTION
# 既存言語の内容を改善する場合

## 変更している内容とその理由

<!--
今回のPRの概要とその理由を簡潔に説明してください。
段階的に改善する場合には後続の対応の見通しも教えてください。
-->

#2 で導入したヘルパー関数の実装に不備があった(期待通りに効いていなかった)ため修正した。

## チェックリスト

- [x] 変更内容に合理的な理由があることを上記セクションで説明した
- [x] [CONTRIBUTING.md](https://github.com/fp-matsuri/fp-in-scala-exercises/blob/main/CONTRIBUTING.md)の問題作成方針に沿って作成した
- [x] 不要な(自動生成)ファイルが含まれないように適切に `.gitignore` されている
- [x] [テストコードがある場合] `exercises` 配下に `answers` 相当の解答例を反映するとすべてのテストケースがパスする
    - ℹ️ テストコードで指定しているテスト対象モジュールを `exercises` から `answers` のものに切り替えて試すのが楽かも
- [x] [リンター/フォーマッターがある場合] `exercises` 配下の未実装箇所周辺(演習問題のための未使用変数/関数など)を除いてすべてのチェックがパスする
