### PR TITLE
devenv/direnv による開発環境の整備と Dev Container 対応

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "fp-in-scala-exercises",
+  "image": "ghcr.io/cachix/devenv:latest",
+  "features": {
+    "ghcr.io/devcontainers-extra/features/direnv:1": {}
+  },
+  "onCreateCommand": "find /workspaces -maxdepth 2 -name '.envrc' -exec direnv allow {} \\;",
+  "postStartCommand": "eval \"$(direnv hook bash)\" && direnv reload",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "direnv.path.executable": "/usr/bin/direnv"
+      },
+      "extensions": [
+        "mkhl.direnv",
+        "betterthantomorrow.calva",
+        "haskell.haskell",
+        "scalameta.metals"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,12 +4,17 @@
   "features": {
     "ghcr.io/devcontainers-extra/features/direnv:1": {}
   },
+  "containerEnv": {
+    "XDG_CACHE_HOME": "/tmp/devenv-cache"
+  },
+  "postCreateCommand": "find /workspaces -maxdepth 3 -name '.envrc' -exec direnv allow {} + && echo 'eval \"$(direnv hook bash)\"' >> ~/.bashrc",
   "onCreateCommand": "find /workspaces -maxdepth 2 -name '.envrc' -exec direnv allow {} \\;",
-  "postStartCommand": "eval \"$(direnv hook bash)\" && direnv reload",
   "customizations": {
     "vscode": {
       "settings": {
-        "direnv.path.executable": "/usr/bin/direnv"
+        "direnv.path.executable": "/nix/var/nix/profiles/default/bin/direnv",
+        "direnv.restart.automatic": true,
+        "terminal.integrated.defaultProfile.linux": "bash"
       },
       "extensions": [
         "mkhl.direnv",
@@ -18,5 +23,6 @@
         "scalameta.metals"
       ]
     }
-  }
+  },
+  "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,7 @@
   "containerEnv": {
     "XDG_CACHE_HOME": "/tmp/devenv-cache"
   },
-  "postCreateCommand": "find /workspaces -maxdepth 3 -name '.envrc' -exec direnv allow {} + && echo 'eval \"$(direnv hook bash)\"' >> ~/.bashrc",
-  "onCreateCommand": "find /workspaces -maxdepth 2 -name '.envrc' -exec direnv allow {} \\;",
+  "onCreateCommand": "find /workspaces -maxdepth 3 -name '.envrc' -exec direnv allow {} + && echo 'eval \"$(direnv hook bash)\"' >> ~/.bashrc",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# claude
+.claude/
+
+# devenv が生成する一時ファイル
+.devenv/
+.devenv.flake.nix
+.devenv.instructions
+
+# direnv が生成する一時ファイル
+.direnv/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 
 # direnv が生成する一時ファイル
 .direnv/
+
+.lsp/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.watcherExclude": {
+    "**/target": true
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 概要
+
+*Functional Programming in Scala, Second Edition* (FP in Scala) の演習問題を複数言語に移植したリポジトリ。ルートに `fp-in-{言語名}/` 形式のディレクトリが並び、それぞれが独立したプロジェクトになっている。
+
+現在の実装状況:
+- **Clojure** (`fp-in-clojure/`) — 実装済み
+- **Haskell** (`fp-in-haskell/`) — プレースホルダーのみ
+- **Scala** (`fp-in-scala/`) — プレースホルダーのみ
+
+各言語ディレクトリは独自のビルドツール・テスト・リンター・フォーマッターを持つ。以下のコマンドは各言語のサブディレクトリ内で実行する。
+
+## Clojure (`fp-in-clojure/`)
+
+### コマンド
+
+```shell
+# 全テストの実行
+clj -X:test
+# または
+make test
+
+# 特定の名前空間のテストの実行
+clj -X:test :nses '[fp-in-clojure.exercises.getting-started.my-program-test]'
+
+# 正規表現にマッチする名前空間のテストの実行
+clj -X:test :patterns '[".+getting-started.+"]'
+
+# 特定のテスト関数のみ実行
+clj -X:test :vars '[fp-in-clojure.exercises.getting-started.my-program-test/factorial-test]'
+
+# REPLの起動(テスト用dependenciesを含む)
+clj -M:test
+
+# 全リンターでリント
+make lint
+
+# clj-kondo のみ
+clj-kondo --lint src
+
+# Joker のみ
+joker --lint --working-dir src
+
+# フォーマットチェック
+cljstyle check
+
+# フォーマット修正
+cljstyle fix
+```
+
+### アーキテクチャ
+
+- `src/fp_in_clojure/exercises/` — 演習問題のスタブ(学習者が実装する)
+- `src/fp_in_clojure/answers/` — 解答例
+- `test/fp_in_clojure/exercises/` — exercises を対象としたテスト(answers ではない)
+
+テストは `clojure.test` と `test.check` によるプロパティベーステストを使用する。`clojure.spec.alpha` のスペックはテスト実行時に `test-helper/instrument-specs` によって自動的にインストルメント化され、テスト対象の名前空間のスペックチェックが有効になる。
+
+解答例で動作確認したい場合は、テストファイル内の `#_[fp-in-clojure.answers....]` のコメントアウト(`#_`)を外し、exercises の require をコメントアウトする。
+
+演習の章構成は書籍に対応している:
+- `getting-started` — Ch.2: 基本的なFP概念・末尾再帰・高階関数
+- 以降の章(データ構造・エラー処理など)は README.md の部/章構成に対応
+
+## 新規言語の追加
+
+[CONTRIBUTING.md](CONTRIBUTING.md) の手順を参照。`fp-in-{言語名}/` の作成、`.gitignore` の追加、exercises/answers の移植、テスト・リンター・フォーマッターの導入、「必要なツール」「使い方」「プロジェクト構成」を含む `README.md` の作成が必要。

--- a/SETUP.md
+++ b/SETUP.md
@@ -31,8 +31,7 @@ direnv hook fish | source
 git clone https://github.com/fp-matsuri/fp-in-scala-exercises
 cd fp-in-scala-exercises
 
-# ルートおよび各サブプロジェクトの .envrc を信頼する
-direnv allow
+# 各サブプロジェクトの .envrc を信頼する
 direnv allow fp-in-clojure
 direnv allow fp-in-haskell
 direnv allow fp-in-scala
@@ -71,13 +70,6 @@ fmt    # フォーマット
 repl   # REPL 起動
 ```
 
-### 各言語の環境詳細
-
-| ディレクトリ | 言語 | 主なツール |
-|------------|------|-----------|
-| `fp-in-clojure/` | Clojure + Java 21 | clj-kondo, cljstyle, joker |
-| `fp-in-haskell/` | Haskell (GHC) | cabal, hlint, ormolu, HLS |
-| `fp-in-scala/` | Scala 3 + Java 21 | sbt, scalafmt, metals |
 
 ## VS Code / Dev Container で使う
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,89 @@
+# 開発環境のセットアップ
+
+このリポジトリは [devenv](https://devenv.sh/) と [direnv](https://direnv.net/) を使って開発環境を管理します。
+
+## 必要なツール
+
+| ツール | 役割 | インストール方法 |
+|--------|------|----------------|
+| [Nix](https://nixos.org/download/) | パッケージ管理 | `sh <(curl -L https://nixos.org/nix/install)` |
+| [devenv](https://devenv.sh/getting-started/) | 開発環境定義 | `nix-env -iA devenv -f https://github.com/NixOS/nixpkgs/tarball/nixpkgs-unstable` |
+| [direnv](https://direnv.net/docs/installation.html) | nix PATH の自動設定 | `nix-env -i direnv` |
+
+### direnv のシェル統合
+
+direnv はシェルのフックに組み込む必要があります。シェルに応じて設定ファイルに以下を追記し、シェルを再起動してください。
+
+```bash
+# ~/.bashrc
+eval "$(direnv hook bash)"
+
+# ~/.zshrc
+eval "$(direnv hook zsh)"
+
+# ~/.config/fish/config.fish
+direnv hook fish | source
+```
+
+## 初回セットアップ
+
+```bash
+git clone https://github.com/fp-matsuri/fp-in-scala-exercises
+cd fp-in-scala-exercises
+
+# ルートおよび各サブプロジェクトの .envrc を信頼する
+direnv allow
+direnv allow fp-in-clojure
+direnv allow fp-in-haskell
+direnv allow fp-in-scala
+```
+
+## 使い方
+
+### 1. サブプロジェクトのディレクトリに移動する
+
+```bash
+cd fp-in-clojure   # Clojure の演習
+cd fp-in-haskell   # Haskell の演習
+cd fp-in-scala     # Scala の演習
+```
+
+direnv が `.envrc` を検知し、nix の PATH を自動で設定します。
+
+### 2. devenv shell で開発環境に入る
+
+各サブプロジェクトディレクトリ内で以下を実行します。
+
+```bash
+devenv shell
+```
+
+初回は devenv.nix の内容に従ってパッケージをダウンロード・ビルドします（数分かかる場合があります）。2回目以降はキャッシュが効くため高速に起動します。
+
+### 3. 開発用コマンドを使う
+
+`devenv shell` の中で以下のコマンドが使えます。
+
+```bash
+tests  # テスト実行
+lint   # リント
+fmt    # フォーマット
+repl   # REPL 起動
+```
+
+### 各言語の環境詳細
+
+| ディレクトリ | 言語 | 主なツール |
+|------------|------|-----------|
+| `fp-in-clojure/` | Clojure + Java 21 | clj-kondo, cljstyle, joker |
+| `fp-in-haskell/` | Haskell (GHC) | cabal, hlint, ormolu, HLS |
+| `fp-in-scala/` | Scala 3 + Java 21 | sbt, scalafmt, metals |
+
+## VS Code / Dev Container で使う
+
+`.devcontainer/devcontainer.json` が用意されています。
+
+1. VS Code で本リポジトリを開く
+2. コマンドパレット（`Cmd+Shift+P`）から「Dev Containers: Reopen in Container」を選ぶ
+
+コンテナ内では各言語の拡張機能（Calva・Haskell・Metals）がインストールされた状態で開発を始められます。

--- a/fp-in-clojure/.envrc
+++ b/fp-in-clojure/.envrc
@@ -1,0 +1,7 @@
+# direnv は --norc --noprofile で bash を起動するため nix の PATH を手動で追加する
+if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+if [ -e "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+  source "$HOME/.nix-profile/etc/profile.d/nix.sh"
+fi

--- a/fp-in-clojure/devenv.lock
+++ b/fp-in-clojure/devenv.lock
@@ -17,6 +17,62 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775585728,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762808025,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "inputs": {
         "nixpkgs-src": "nixpkgs-src"
@@ -56,7 +112,11 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "nixpkgs": "nixpkgs"
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
       }
     }
   },

--- a/fp-in-clojure/devenv.lock
+++ b/fp-in-clojure/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1776718099,
+        "narHash": "sha256-JAR6x8Au4xxk6X7ijhlYETQg0F0OS0ihZ5ARiguDclc=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "034b677ee035a29a077ecbaadfb2908719272919",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1776771808,
+        "narHash": "sha256-FRpraDgknF5zoCYTi9CitoIaUYb/XGiXUuVqPg9AYB4=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "3a3d4ac6ea3dbf2534ef988086348b7e140b92ad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/fp-in-clojure/devenv.nix
+++ b/fp-in-clojure/devenv.nix
@@ -3,7 +3,7 @@
 {
   languages.java = {
     enable = true;
-    jdk.package = pkgs.jdk21;
+    jdk.package = pkgs.jdk25;
   };
 
   languages.clojure.enable = true;
@@ -18,7 +18,7 @@
   scripts = {
     tests.exec = ''clj -X:test "$@"'';
     lint.exec = "make lint";
-    fmt.exec = "cljstyle fix";
+    fmt.exec = "make cljstyle-fix";
     repl.exec = "clj -M:test";
   };
 }

--- a/fp-in-clojure/devenv.nix
+++ b/fp-in-clojure/devenv.nix
@@ -1,0 +1,24 @@
+{ pkgs, ... }:
+
+{
+  languages.java = {
+    enable = true;
+    jdk.package = pkgs.jdk21;
+  };
+
+  languages.clojure.enable = true;
+
+  packages = with pkgs; [
+    git
+    clj-kondo
+    cljstyle
+    joker
+  ];
+
+  scripts = {
+    tests.exec = ''clj -X:test "$@"'';
+    lint.exec = "make lint";
+    fmt.exec = "cljstyle fix";
+    repl.exec = "clj -M:test";
+  };
+}

--- a/fp-in-haskell/.envrc
+++ b/fp-in-haskell/.envrc
@@ -1,0 +1,7 @@
+# direnv は --norc --noprofile で bash を起動するため nix の PATH を手動で追加する
+if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+if [ -e "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+  source "$HOME/.nix-profile/etc/profile.d/nix.sh"
+fi

--- a/fp-in-haskell/devenv.lock
+++ b/fp-in-haskell/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1776778536,
+        "narHash": "sha256-P+w7Gons5V+q/Ezfjr/xhq+jAL15Ou2RqY8he8QUaXc=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "45021a3d572bc961ba63006969390d5ae9001af0",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1776771808,
+        "narHash": "sha256-FRpraDgknF5zoCYTi9CitoIaUYb/XGiXUuVqPg9AYB4=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "3a3d4ac6ea3dbf2534ef988086348b7e140b92ad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/fp-in-haskell/devenv.nix
+++ b/fp-in-haskell/devenv.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+
+{
+  languages.haskell = {
+    enable = true;
+    package = pkgs.ghc;
+  };
+
+  packages = with pkgs; [
+    cabal-install
+    haskellPackages.hlint
+    haskellPackages.ormolu
+    haskell-language-server
+  ];
+
+  scripts = {
+    tests.exec = "cabal test";
+    lint.exec = ''hlint $(find src -name "*.hs")'';
+    fmt.exec = ''ormolu --mode inplace $(find src -name "*.hs")'';
+    repl.exec = "cabal repl";
+  };
+}

--- a/fp-in-haskell/devenv.nix
+++ b/fp-in-haskell/devenv.nix
@@ -14,9 +14,5 @@
   ];
 
   scripts = {
-    tests.exec = "cabal test";
-    lint.exec = ''hlint $(find src -name "*.hs")'';
-    fmt.exec = ''ormolu --mode inplace $(find src -name "*.hs")'';
-    repl.exec = "cabal repl";
   };
 }

--- a/fp-in-scala/.envrc
+++ b/fp-in-scala/.envrc
@@ -1,0 +1,7 @@
+# direnv は --norc --noprofile で bash を起動するため nix の PATH を手動で追加する
+if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+if [ -e "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+  source "$HOME/.nix-profile/etc/profile.d/nix.sh"
+fi

--- a/fp-in-scala/build.sbt
+++ b/fp-in-scala/build.sbt
@@ -1,0 +1,2 @@
+ThisBuild / scalaVersion := "3.3.4"
+ThisBuild / semanticdbEnabled := true

--- a/fp-in-scala/devenv.lock
+++ b/fp-in-scala/devenv.lock
@@ -17,6 +17,62 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775585728,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762808025,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "inputs": {
         "nixpkgs-src": "nixpkgs-src"
@@ -56,7 +112,11 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "nixpkgs": "nixpkgs"
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
       }
     }
   },

--- a/fp-in-scala/devenv.lock
+++ b/fp-in-scala/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1776718099,
+        "narHash": "sha256-JAR6x8Au4xxk6X7ijhlYETQg0F0OS0ihZ5ARiguDclc=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "034b677ee035a29a077ecbaadfb2908719272919",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1776771808,
+        "narHash": "sha256-FRpraDgknF5zoCYTi9CitoIaUYb/XGiXUuVqPg9AYB4=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "3a3d4ac6ea3dbf2534ef988086348b7e140b92ad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/fp-in-scala/devenv.nix
+++ b/fp-in-scala/devenv.nix
@@ -13,14 +13,13 @@
 
   packages = with pkgs; [
     sbt
-    scalafmt
     metals
   ];
 
   scripts = {
     tests.exec = "sbt test";
     lint.exec = "sbt scalafix";
-    fmt.exec = "scalafmt";
+    fmt.exec = "sbt scalafmt";
     repl.exec = "sbt console";
   };
 }

--- a/fp-in-scala/devenv.nix
+++ b/fp-in-scala/devenv.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+
+{
+  languages.java = {
+    enable = true;
+    jdk.package = pkgs.jdk21;
+  };
+
+  languages.scala = {
+    enable = true;
+    package = pkgs.scala_3;
+  };
+
+  packages = with pkgs; [
+    sbt
+    scalafmt
+    metals
+  ];
+
+  scripts = {
+    tests.exec = "sbt test";
+    lint.exec = "sbt scalafix";
+    fmt.exec = "scalafmt";
+    repl.exec = "sbt console";
+  };
+}

--- a/fp-in-scala/project/build.properties
+++ b/fp-in-scala/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.4

--- a/fp-in-scala/project/plugins.sbt
+++ b/fp-in-scala/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")


### PR DESCRIPTION
## 概要

- 全3言語プロジェクト（Clojure・Haskell・Scala）に [devenv](https://devenv.sh/) + [direnv](https://direnv.net/) ベースの開発環境を追加
- VS Code の Dev Container 設定を追加し、コンテナ一発でどの言語の演習にも取り組める環境を実現
- SETUP.md でセットアップ手順を文書化
- CLAUDE.md を追加し Claude Code への文脈共有を整備