### PR TITLE
getting-startedの問題と解答例を改善

### DIFF
--- a/fp-in-clojure/src/fp_in_clojure/answers/getting_started/my_program.clj
+++ b/fp-in-clojure/src/fp_in_clojure/answers/getting_started/my_program.clj
@@ -74,13 +74,13 @@
 
 (defn fib [n]
   (loop [n n
-         prev 0
-         curr 1]
+         current 0
+         next 1]
     (if (<= n 0)
-      prev
+      current
       (recur (dec n)
-             curr
-             (+' prev curr)))))
+             next
+             (+' current next)))))
 
 ;; この定義と `format-abs` はとてもよく似ている。
 

--- a/fp-in-clojure/src/fp_in_clojure/answers/getting_started/polymorphic_functions.clj
+++ b/fp-in-clojure/src/fp_in_clojure/answers/getting_started/polymorphic_functions.clj
@@ -75,6 +75,9 @@
 (defn uncurry [f]
   (fn [a b] ((f a) b)))
 
+;; これら2つの形式を行き来できることに注目しよう。curryしてuncurryすることができ、これら2つの形式はある意味で「同じ」だといえる。
+;; FPの専門用語では、これらは _同型(isomorphic)_ ("iso" = same; "morphe" = shape, form)であると言い、圏論(category theory)から引き継がれた用語だ。
+
 ;; Exercise 2.5: `compose` を実装せよ。
 ;; 引数 `f`, `g` 、戻り値はいずれも引数を1つとる関数。
 ;; Scala風の型表記: `compose: (f: B => C, g: A => B) => (A => C)`

--- a/fp-in-clojure/src/fp_in_clojure/exercises/getting_started/polymorphic_functions.clj
+++ b/fp-in-clojure/src/fp_in_clojure/exercises/getting_started/polymorphic_functions.clj
@@ -74,6 +74,9 @@
   ;; TODO
   )
 
+;; これら2つの形式を行き来できることに注目しよう。curryしてuncurryすることができ、これら2つの形式はある意味で「同じ」だといえる。
+;; FPの専門用語では、これらは _同型(isomorphic)_ ("iso" = same; "morphe" = shape, form)であると言い、圏論(category theory)から引き継がれた用語だ。
+
 ;; Exercise 2.5: `compose` を実装せよ。
 ;; 引数 `f`, `g` 、戻り値はいずれも引数を1つとる関数。
 ;; Scala風の型表記: `compose: (f: B => C, g: A => B) => (A => C)`


### PR DESCRIPTION

# 既存言語の内容を改善する場合

## 変更している内容とその理由

<!--
今回のPRの概要とその理由を簡潔に説明してください。
段階的に改善する場合には後続の対応の見通しも教えてください。
-->

Clojure版のgetting-startedの実装に軽微な改善を加えた。

- Scala版のコメント説明の反映漏れを修正
- fibの実装例を改善

## チェックリスト

- [x] 変更内容に合理的な理由があることを上記セクションで説明した
- [x] [CONTRIBUTING.md](https://github.com/fp-matsuri/fp-in-scala-exercises/blob/main/CONTRIBUTING.md)の問題作成方針に沿って作成した
- [x] 不要な(自動生成)ファイルが含まれないように適切に `.gitignore` されている
- [x] [テストコードがある場合] `exercises` 配下に `answers` 相当の解答例を反映するとすべてのテストケースがパスする
    - ℹ️ テストコードで指定しているテスト対象モジュールを `exercises` から `answers` のものに切り替えて試すのが楽かも
- [x] [リンター/フォーマッターがある場合] `exercises` 配下の未実装箇所周辺(演習問題のための未使用変数/関数など)を除いてすべてのチェックがパスする
