### PR TITLE
fp-in-sml を追加

### DIFF
--- a/.github/workflows/fp-in-sml.yml
+++ b/.github/workflows/fp-in-sml.yml
@@ -1,0 +1,42 @@
+name: fp-in-sml CI
+
+on:
+  push:
+    paths:
+      - "fp-in-sml/**"
+      - ".github/workflows/fp-in-sml.yml"
+  pull_request:
+    paths:
+      - "fp-in-sml/**"
+      - ".github/workflows/fp-in-sml.yml"
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: fp-in-sml
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      # 解答の検証 (すべて pass する)
+      - name: MLton answers (expect all pass)
+        run: nix develop --command make answers
+
+      # 演習の検証 (未実装は todo 表示)
+      - name: MLton exercises (expect compile + todo, no failures)
+        run: nix develop --command make test
+
+      # SML/NJ でも同様に検証
+      - name: SML/NJ answers (expect all pass)
+        run: nix develop --command make nj-answers
+
+      - name: SML/NJ exercises (expect compile + todo, no failures)
+        run: nix develop --command make nj-test

--- a/fp-in-sml/.gitignore
+++ b/fp-in-sml/.gitignore
@@ -1,0 +1,11 @@
+# MLton が生成する実行ファイル
+build/run-exercises
+build/run-answers
+
+# SML/NJ (Compilation Manager) のキャッシュ
+.cm/
+**/.cm/
+
+# Nix
+result
+result-*

--- a/fp-in-sml/Main.sml
+++ b/fp-in-sml/Main.sml
@@ -1,0 +1,4 @@
+(* MLton 用のエントリポイントです．
+ * 全テストを実行し終了コードを返します．
+ * SML/NJ の REPL では読み込まず CM.make の後で Test.run () を呼びます． *)
+val _ = OS.Process.exit (Test.run ())

--- a/fp-in-sml/Makefile
+++ b/fp-in-sml/Makefile
@@ -1,0 +1,54 @@
+# fp-in-sml: Functional Programming in Scala の演習を Standard ML で解く
+#
+# Usage:  make test          演習を MLton でビルドして全てのテストを実行 (未実装のものは todo 表示)
+#         make answers       解答を MLton でビルドして全てのテストを実行 (すべてパスすることを期待)
+#         make test CH=ch03  章ごとのフィルタ (テスト名の部分一致)
+#         make repl          SML/NJ の REPL を起動 (CM.make の読み込み後に Test.run を実行)
+#         make nj-test       演習を SML/NJ で非対話実行 (CI で利用)
+#         make nj-answers    解答を SML/NJ で非対話実行 (CI で利用)
+#         make fmt           smlfmt でコードを整形
+#         make clean         ビルド生成物の削除
+
+MLTON ?= mlton
+SML   ?= sml
+SMLFMT ?= smlfmt
+
+BUILD := build
+CH    ?=
+
+EXE_EXERCISES := $(BUILD)/run-exercises
+EXE_ANSWERS   := $(BUILD)/run-answers
+
+.PHONY: test answers repl nj-test nj-answers fmt clean
+
+test:
+	$(MLTON) -output $(EXE_EXERCISES) $(BUILD)/exercises.mlb
+	./$(EXE_EXERCISES) $(CH)
+
+answers:
+	$(MLTON) -output $(EXE_ANSWERS) $(BUILD)/answers.mlb
+	./$(EXE_ANSWERS) $(CH)
+
+repl:
+	@echo '== SML/NJ REPL =='
+	@echo '演習側のビルドとテスト:  CM.make "$(BUILD)/exercises.cm"; Test.run ();'
+	@echo '解答側のビルドとテスト:  CM.make "$(BUILD)/answers.cm";   Test.run ();'
+	@if command -v rlwrap >/dev/null 2>&1; then \
+		rlwrap $(SML); \
+	else \
+		$(SML); \
+	fi
+
+# SML/NJ で非対話実行．(CM.make → Test.run の終了コードで成否を返す)
+# OS.Process.exit は戻り型が 'a なので，トップレベル式のままだと値制限の警告が出ます．
+nj-test:
+	@printf 'CM.make "$(BUILD)/exercises.cm";\nval _ = OS.Process.exit (Test.run ());\n' | $(SML)
+
+nj-answers:
+	@printf 'CM.make "$(BUILD)/answers.cm";\nval _ = OS.Process.exit (Test.run ());\n' | $(SML)
+
+fmt:
+	$(SMLFMT) --force $(BUILD)/exercises.mlb $(BUILD)/answers.mlb
+
+clean:
+	rm -f $(EXE_EXERCISES) $(EXE_ANSWERS)

--- a/fp-in-sml/README.md
+++ b/fp-in-sml/README.md
@@ -1,0 +1,91 @@
+# fp-in-sml
+
+[Functional Programming in Scala, Second Edition](https://www.manning.com/books/functional-programming-in-scala-second-edition) の演習を Standard ML (SML) で解くハンズオン教材です．
+
+Scala や Haskell の知識は前提にしません．SML の経験が無ければ [`docs/sml-primer.md`](docs/sml-primer.md) を一読してください．
+
+## 収録内容
+
+- 本書の各章を SML のモジュールシステムで実装しながら学びます．
+- なるべく処理系に依存しないように作ります．MLton と SML/NJ の両方で動くことを期待しています．
+  - `parallelism` については，並行 API (CML など) が処理系ごとに異なるため含めません．
+  - `laziness` については，標準ライブラリに遅延リストが無いので Stream をサンクで再現します．SML/NJ の拡張機能は利用しません．
+- `localeffects` は ST モナドを扱わずクイックソートのみに絞ります．
+  - 可変性を型に閉じ込めることが主題ですが，SML では関数内の `ref` / 配列で副作用を隠蔽するのが自然な設計です．
+
+## 準備
+
+| ツール | 用途 |
+| --- | --- |
+| [MLton](http://mlton.org/) | `make test` で演習をビルド・テスト |
+| [SML/NJ](https://www.smlnj.org/) | `make repl` で対話的に試す |
+| [smlfmt](https://github.com/shwestrick/smlfmt) | `make fmt` でコード整形 (必要であれば) |
+| [Millet](https://github.com/azdavis/millet) | エディタ補完 (必要であれば) |
+
+[`flake.nix`](flake.nix) で上記を揃えられます．
+
+```bash
+cd fp-in-sml
+nix develop
+make test
+```
+
+Homebrew を使う場合は `brew install mlton smlnj smlfmt` で入ります．
+
+apt を使う場合は `sudo apt install -y mlton smlnj` で入ります．(`smlfmt` と Millet は別途)
+
+## 演習の進め方
+
+1. 章のシグネチャ `src/chNN_*/XXX.sig` で求められる関数を確認する．Basis と衝突する型やモジュール (`MyList`, `MyOption`, `MyIO` など) には `My` 接頭辞が付きます．
+2. `src/chNN_*/exercises/XXX.sml` の `Stub.todo ()` を自分の実装に置き換えます．
+3. `make test` でテストを実行します．
+
+```bash
+make test            # 全テスト (未実装は todo と表示)
+make test CH=ch03    # 章で絞る (テスト名の部分一致)
+make repl            # REPL で試す
+make fmt             # smlfmt でコード整形
+```
+
+REPL を開いた場合は，以下のようにして読み込めます．
+
+```sml
+CM.make "build/exercises.cm";
+Test.run ();
+```
+
+`make test` の表示は以下の通りです．
+
+- `ok` → 正しい
+- `FAIL` → 期待している結果と不一致
+- `todo` → まだ `Stub.todo ()` のまま
+
+解答例は `src/chNN_*/answers/` にあります．`make answers` で解答側のテストを確認できます (自分の実装の検証には使いません)．
+
+## エディタ
+
+VS Code の拡張で [Millet](https://marketplace.visualstudio.com/items?itemName=azdavis.millet) があります．
+
+Neovim の場合は `require('lspconfig').millet.setup({})` でいけます．`millet.toml` があるので `fp-in-sml/` をルートに開いてください．
+
+## 章の一覧
+
+| 章 | 題材 |
+| --- | --- |
+| 2 | gettingstarted |
+| 3 | datastructures |
+| 4 | errorhandling |
+| 5 | laziness |
+| 6 | state |
+| 8 | testing |
+| 9 | parsing |
+| 10 | monoids |
+| 11 | monads |
+| 12 | applicative |
+| 13 | iomonad |
+| 14 | localeffects |
+| 15 | streamingio |
+
+---
+
+リポジトリの拡張や CI 追加など，保守者に向けた情報は [`docs/maintain.md`](docs/maintain.md) を参照してください．

--- a/fp-in-sml/build/answers.cm
+++ b/fp-in-sml/build/answers.cm
@@ -1,0 +1,88 @@
+(* SML/NJ (CM) で解答側を読み込む．
+ * CM.make "build/answers.cm"; Test.run (); でビルドとテストを実行する．
+ * Main.sml は含めない．含めると Test.run の中で REPL ごと exit してしまう． *)
+Group is
+  $/basis.cm
+  ../lib/lib.cm
+
+  (* ch02 gettingstarted *)
+  ../src/ch02_gettingstarted/INTRO.sig
+  ../src/ch02_gettingstarted/answers/Intro.sml
+  ../test/ch02_gettingstarted/IntroTest.sml
+
+  (* ch03 datastructures *)
+  ../src/ch03_datastructures/MY_LIST.sig
+  ../src/ch03_datastructures/answers/MyList.sml
+  ../src/ch03_datastructures/TREE.sig
+  ../src/ch03_datastructures/answers/Tree.sml
+  ../test/ch03_datastructures/MyListTest.sml
+  ../test/ch03_datastructures/TreeTest.sml
+
+  (* ch04 errorhandling *)
+  ../src/ch04_errorhandling/MY_OPTION.sig
+  ../src/ch04_errorhandling/answers/MyOption.sml
+  ../src/ch04_errorhandling/EITHER.sig
+  ../src/ch04_errorhandling/answers/Either.sml
+  ../test/ch04_errorhandling/MyOptionTest.sml
+  ../test/ch04_errorhandling/EitherTest.sml
+
+  (* ch05 laziness *)
+  ../src/ch05_laziness/LAZY_LIST.sig
+  ../src/ch05_laziness/answers/LazyList.sml
+  ../test/ch05_laziness/LazyListTest.sml
+
+  (* ch06 state *)
+  ../src/ch06_state/RNG.sig
+  ../src/ch06_state/answers/Rng.sml
+  ../src/ch06_state/STATE.sig
+  ../src/ch06_state/answers/State.sml
+  ../test/ch06_state/RngTest.sml
+  ../test/ch06_state/StateTest.sml
+
+  (* ch08 testing *)
+  ../src/ch08_testing/GEN.sig
+  ../src/ch08_testing/answers/Gen.sml
+  ../src/ch08_testing/PROP.sig
+  ../src/ch08_testing/answers/Prop.sml
+  ../test/ch08_testing/GenTest.sml
+  ../test/ch08_testing/PropTest.sml
+
+  (* ch09 parsing *)
+  ../src/ch09_parsing/PARSER.sig
+  ../src/ch09_parsing/answers/Parser.sml
+  ../src/ch09_parsing/JSON.sig
+  ../src/ch09_parsing/Json.sml
+  ../test/ch09_parsing/ParserTest.sml
+  ../test/ch09_parsing/JsonTest.sml
+
+  (* ch10 monoids *)
+  ../src/ch10_monoids/MONOID.sig
+  ../src/ch10_monoids/answers/Monoids.sml
+  ../test/ch10_monoids/MonoidsTest.sml
+
+  (* ch11 monads *)
+  ../src/ch11_monads/MONAD.sig
+  ../src/ch11_monads/answers/MonadUtil.sml
+  ../src/ch11_monads/MonadInstances.sml
+  ../test/ch11_monads/MonadTest.sml
+
+  (* ch12 applicative *)
+  ../src/ch12_applicative/APPLICATIVE.sig
+  ../src/ch12_applicative/answers/ApplicativeUtil.sml
+  ../src/ch12_applicative/ApplicativeInstances.sml
+  ../test/ch12_applicative/ApplicativeTest.sml
+
+  (* ch13 iomonad *)
+  ../src/ch13_iomonad/MY_IO.sig
+  ../src/ch13_iomonad/answers/MyIO.sml
+  ../test/ch13_iomonad/MyIOTest.sml
+
+  (* ch14 localeffects *)
+  ../src/ch14_localeffects/LOCAL_EFFECTS.sig
+  ../src/ch14_localeffects/answers/LocalEffects.sml
+  ../test/ch14_localeffects/LocalEffectsTest.sml
+
+  (* ch15 streamingio *)
+  ../src/ch15_streamingio/PROCESS.sig
+  ../src/ch15_streamingio/answers/Process.sml
+  ../test/ch15_streamingio/ProcessTest.sml

--- a/fp-in-sml/build/answers.mlb
+++ b/fp-in-sml/build/answers.mlb
@@ -1,0 +1,90 @@
+(* 解答をビルドする MLton のバッチ定義です．
+ * 並び順に意味があります．
+ * シグネチャ → 実装 → テスト → Main と並べること． *)
+../lib/lib.mlb
+
+ann "allowExtendedTextConsts true" in
+  (* ch02 gettingstarted *)
+  ../src/ch02_gettingstarted/INTRO.sig
+  ../src/ch02_gettingstarted/answers/Intro.sml
+  ../test/ch02_gettingstarted/IntroTest.sml
+
+  (* ch03 datastructures *)
+  ../src/ch03_datastructures/MY_LIST.sig
+  ../src/ch03_datastructures/answers/MyList.sml
+  ../src/ch03_datastructures/TREE.sig
+  ../src/ch03_datastructures/answers/Tree.sml
+  ../test/ch03_datastructures/MyListTest.sml
+  ../test/ch03_datastructures/TreeTest.sml
+
+  (* ch04 errorhandling *)
+  ../src/ch04_errorhandling/MY_OPTION.sig
+  ../src/ch04_errorhandling/answers/MyOption.sml
+  ../src/ch04_errorhandling/EITHER.sig
+  ../src/ch04_errorhandling/answers/Either.sml
+  ../test/ch04_errorhandling/MyOptionTest.sml
+  ../test/ch04_errorhandling/EitherTest.sml
+
+  (* ch05 laziness *)
+  ../src/ch05_laziness/LAZY_LIST.sig
+  ../src/ch05_laziness/answers/LazyList.sml
+  ../test/ch05_laziness/LazyListTest.sml
+
+  (* ch06 state *)
+  ../src/ch06_state/RNG.sig
+  ../src/ch06_state/answers/Rng.sml
+  ../src/ch06_state/STATE.sig
+  ../src/ch06_state/answers/State.sml
+  ../test/ch06_state/RngTest.sml
+  ../test/ch06_state/StateTest.sml
+
+  (* ch08 testing *)
+  ../src/ch08_testing/GEN.sig
+  ../src/ch08_testing/answers/Gen.sml
+  ../src/ch08_testing/PROP.sig
+  ../src/ch08_testing/answers/Prop.sml
+  ../test/ch08_testing/GenTest.sml
+  ../test/ch08_testing/PropTest.sml
+
+  (* ch09 parsing *)
+  ../src/ch09_parsing/PARSER.sig
+  ../src/ch09_parsing/answers/Parser.sml
+  ../src/ch09_parsing/JSON.sig
+  ../src/ch09_parsing/Json.sml
+  ../test/ch09_parsing/ParserTest.sml
+  ../test/ch09_parsing/JsonTest.sml
+
+  (* ch10 monoids *)
+  ../src/ch10_monoids/MONOID.sig
+  ../src/ch10_monoids/answers/Monoids.sml
+  ../test/ch10_monoids/MonoidsTest.sml
+
+  (* ch11 monads *)
+  ../src/ch11_monads/MONAD.sig
+  ../src/ch11_monads/answers/MonadUtil.sml
+  ../src/ch11_monads/MonadInstances.sml
+  ../test/ch11_monads/MonadTest.sml
+
+  (* ch12 applicative *)
+  ../src/ch12_applicative/APPLICATIVE.sig
+  ../src/ch12_applicative/answers/ApplicativeUtil.sml
+  ../src/ch12_applicative/ApplicativeInstances.sml
+  ../test/ch12_applicative/ApplicativeTest.sml
+
+  (* ch13 iomonad *)
+  ../src/ch13_iomonad/MY_IO.sig
+  ../src/ch13_iomonad/answers/MyIO.sml
+  ../test/ch13_iomonad/MyIOTest.sml
+
+  (* ch14 localeffects *)
+  ../src/ch14_localeffects/LOCAL_EFFECTS.sig
+  ../src/ch14_localeffects/answers/LocalEffects.sml
+  ../test/ch14_localeffects/LocalEffectsTest.sml
+
+  (* ch15 streamingio *)
+  ../src/ch15_streamingio/PROCESS.sig
+  ../src/ch15_streamingio/answers/Process.sml
+  ../test/ch15_streamingio/ProcessTest.sml
+
+  ../Main.sml
+end

--- a/fp-in-sml/build/exercises.cm
+++ b/fp-in-sml/build/exercises.cm
@@ -1,0 +1,88 @@
+(* SML/NJ (CM) で演習側を読み込む．
+ * CM.make "build/exercises.cm"; Test.run (); でビルドとテストを実行する．
+ * Main.sml は含めない．含めると Test.run の中で REPL ごと exit してしまう． *)
+Group is
+  $/basis.cm
+  ../lib/lib.cm
+
+  (* ch02 gettingstarted *)
+  ../src/ch02_gettingstarted/INTRO.sig
+  ../src/ch02_gettingstarted/exercises/Intro.sml
+  ../test/ch02_gettingstarted/IntroTest.sml
+
+  (* ch03 datastructures *)
+  ../src/ch03_datastructures/MY_LIST.sig
+  ../src/ch03_datastructures/exercises/MyList.sml
+  ../src/ch03_datastructures/TREE.sig
+  ../src/ch03_datastructures/exercises/Tree.sml
+  ../test/ch03_datastructures/MyListTest.sml
+  ../test/ch03_datastructures/TreeTest.sml
+
+  (* ch04 errorhandling *)
+  ../src/ch04_errorhandling/MY_OPTION.sig
+  ../src/ch04_errorhandling/exercises/MyOption.sml
+  ../src/ch04_errorhandling/EITHER.sig
+  ../src/ch04_errorhandling/exercises/Either.sml
+  ../test/ch04_errorhandling/MyOptionTest.sml
+  ../test/ch04_errorhandling/EitherTest.sml
+
+  (* ch05 laziness *)
+  ../src/ch05_laziness/LAZY_LIST.sig
+  ../src/ch05_laziness/exercises/LazyList.sml
+  ../test/ch05_laziness/LazyListTest.sml
+
+  (* ch06 state *)
+  ../src/ch06_state/RNG.sig
+  ../src/ch06_state/exercises/Rng.sml
+  ../src/ch06_state/STATE.sig
+  ../src/ch06_state/exercises/State.sml
+  ../test/ch06_state/RngTest.sml
+  ../test/ch06_state/StateTest.sml
+
+  (* ch08 testing *)
+  ../src/ch08_testing/GEN.sig
+  ../src/ch08_testing/exercises/Gen.sml
+  ../src/ch08_testing/PROP.sig
+  ../src/ch08_testing/exercises/Prop.sml
+  ../test/ch08_testing/GenTest.sml
+  ../test/ch08_testing/PropTest.sml
+
+  (* ch09 parsing *)
+  ../src/ch09_parsing/PARSER.sig
+  ../src/ch09_parsing/exercises/Parser.sml
+  ../src/ch09_parsing/JSON.sig
+  ../src/ch09_parsing/Json.sml
+  ../test/ch09_parsing/ParserTest.sml
+  ../test/ch09_parsing/JsonTest.sml
+
+  (* ch10 monoids *)
+  ../src/ch10_monoids/MONOID.sig
+  ../src/ch10_monoids/exercises/Monoids.sml
+  ../test/ch10_monoids/MonoidsTest.sml
+
+  (* ch11 monads *)
+  ../src/ch11_monads/MONAD.sig
+  ../src/ch11_monads/exercises/MonadUtil.sml
+  ../src/ch11_monads/MonadInstances.sml
+  ../test/ch11_monads/MonadTest.sml
+
+  (* ch12 applicative *)
+  ../src/ch12_applicative/APPLICATIVE.sig
+  ../src/ch12_applicative/exercises/ApplicativeUtil.sml
+  ../src/ch12_applicative/ApplicativeInstances.sml
+  ../test/ch12_applicative/ApplicativeTest.sml
+
+  (* ch13 iomonad *)
+  ../src/ch13_iomonad/MY_IO.sig
+  ../src/ch13_iomonad/exercises/MyIO.sml
+  ../test/ch13_iomonad/MyIOTest.sml
+
+  (* ch14 localeffects *)
+  ../src/ch14_localeffects/LOCAL_EFFECTS.sig
+  ../src/ch14_localeffects/exercises/LocalEffects.sml
+  ../test/ch14_localeffects/LocalEffectsTest.sml
+
+  (* ch15 streamingio *)
+  ../src/ch15_streamingio/PROCESS.sig
+  ../src/ch15_streamingio/exercises/Process.sml
+  ../test/ch15_streamingio/ProcessTest.sml

--- a/fp-in-sml/build/exercises.mlb
+++ b/fp-in-sml/build/exercises.mlb
@@ -1,0 +1,90 @@
+(* 演習をビルドする MLton のバッチ定義です．
+ * 並び順に意味があります．
+ * シグネチャ → 実装 → テスト → Main と並べること． *)
+../lib/lib.mlb
+
+ann "allowExtendedTextConsts true" in
+  (* ch02 gettingstarted *)
+  ../src/ch02_gettingstarted/INTRO.sig
+  ../src/ch02_gettingstarted/exercises/Intro.sml
+  ../test/ch02_gettingstarted/IntroTest.sml
+
+  (* ch03 datastructures *)
+  ../src/ch03_datastructures/MY_LIST.sig
+  ../src/ch03_datastructures/exercises/MyList.sml
+  ../src/ch03_datastructures/TREE.sig
+  ../src/ch03_datastructures/exercises/Tree.sml
+  ../test/ch03_datastructures/MyListTest.sml
+  ../test/ch03_datastructures/TreeTest.sml
+
+  (* ch04 errorhandling *)
+  ../src/ch04_errorhandling/MY_OPTION.sig
+  ../src/ch04_errorhandling/exercises/MyOption.sml
+  ../src/ch04_errorhandling/EITHER.sig
+  ../src/ch04_errorhandling/exercises/Either.sml
+  ../test/ch04_errorhandling/MyOptionTest.sml
+  ../test/ch04_errorhandling/EitherTest.sml
+
+  (* ch05 laziness *)
+  ../src/ch05_laziness/LAZY_LIST.sig
+  ../src/ch05_laziness/exercises/LazyList.sml
+  ../test/ch05_laziness/LazyListTest.sml
+
+  (* ch06 state *)
+  ../src/ch06_state/RNG.sig
+  ../src/ch06_state/exercises/Rng.sml
+  ../src/ch06_state/STATE.sig
+  ../src/ch06_state/exercises/State.sml
+  ../test/ch06_state/RngTest.sml
+  ../test/ch06_state/StateTest.sml
+
+  (* ch08 testing *)
+  ../src/ch08_testing/GEN.sig
+  ../src/ch08_testing/exercises/Gen.sml
+  ../src/ch08_testing/PROP.sig
+  ../src/ch08_testing/exercises/Prop.sml
+  ../test/ch08_testing/GenTest.sml
+  ../test/ch08_testing/PropTest.sml
+
+  (* ch09 parsing *)
+  ../src/ch09_parsing/PARSER.sig
+  ../src/ch09_parsing/exercises/Parser.sml
+  ../src/ch09_parsing/JSON.sig
+  ../src/ch09_parsing/Json.sml
+  ../test/ch09_parsing/ParserTest.sml
+  ../test/ch09_parsing/JsonTest.sml
+
+  (* ch10 monoids *)
+  ../src/ch10_monoids/MONOID.sig
+  ../src/ch10_monoids/exercises/Monoids.sml
+  ../test/ch10_monoids/MonoidsTest.sml
+
+  (* ch11 monads *)
+  ../src/ch11_monads/MONAD.sig
+  ../src/ch11_monads/exercises/MonadUtil.sml
+  ../src/ch11_monads/MonadInstances.sml
+  ../test/ch11_monads/MonadTest.sml
+
+  (* ch12 applicative *)
+  ../src/ch12_applicative/APPLICATIVE.sig
+  ../src/ch12_applicative/exercises/ApplicativeUtil.sml
+  ../src/ch12_applicative/ApplicativeInstances.sml
+  ../test/ch12_applicative/ApplicativeTest.sml
+
+  (* ch13 iomonad *)
+  ../src/ch13_iomonad/MY_IO.sig
+  ../src/ch13_iomonad/exercises/MyIO.sml
+  ../test/ch13_iomonad/MyIOTest.sml
+
+  (* ch14 localeffects *)
+  ../src/ch14_localeffects/LOCAL_EFFECTS.sig
+  ../src/ch14_localeffects/exercises/LocalEffects.sml
+  ../test/ch14_localeffects/LocalEffectsTest.sml
+
+  (* ch15 streamingio *)
+  ../src/ch15_streamingio/PROCESS.sig
+  ../src/ch15_streamingio/exercises/Process.sml
+  ../test/ch15_streamingio/ProcessTest.sml
+
+  ../Main.sml
+end

--- a/fp-in-sml/docs/maintain.md
+++ b/fp-in-sml/docs/maintain.md
@@ -1,0 +1,91 @@
+# 保守者向けの情報
+
+演習の進め方は [README.md](../README.md) にあります．
+
+簡単な SML 入門は [sml-primer.md](sml-primer.md) にあります．
+
+## ファイルの配置
+
+| パス | 内容 |
+| --- | --- |
+| `lib/` | `Stub`, `Pbt`, `Test` と `lib.mlb` / `lib.cm` |
+| `src/chNN_<章>/XXX.sig` | 章の API (exercises / answers 共通) |
+| `src/chNN_<章>/exercises/XXX.sml` | 演習 (未実装) |
+| `src/chNN_<章>/answers/XXX.sml` | 解答 |
+| `test/chNN_<章>/XXXTest.sml` | テスト |
+| `build/exercises.{mlb,cm}` | 演習側の集約 |
+| `build/answers.{mlb,cm}` | 解答側の集約 |
+| `Main.sml` | MLton のエントリ (`Test.run`, CM ビルドには含めない) |
+| `Makefile`, `flake.nix`, `millet.toml` | ビルドと開発環境 |
+| `docs/` | この文書と `sml-primer.md` |
+
+`build/` が同じ `*.sig` に対して `exercises/` と `answers/` のどちらを取り込むか切り替えます．
+
+## 章の追加
+
+収録方針は [README の収録内容](../README.md#収録内容) に従います．
+
+1. `src/chNN_*/XXX.sig` を定義する
+2. `exercises/XXX.sml` と `answers/XXX.sml` を書く ([Stub.todo](#stubtodo))
+3. `test/chNN_*/XXXTest.sml` を書く ([テストの書き方](#テストの書き方))
+4. `build/exercises.mlb`，`build/answers.mlb`，`build/exercises.cm`，`build/answers.cm` に追加する
+5. [検証](#検証) に従って `make ...` による MLton / SML/NJ の結果を確認する (SML コードを編集したなら [整形](#整形) も)
+6. [README の章一覧](../README.md#章の一覧) を更新する
+
+### Stub.todo
+
+`Stub.todo ()` を `val` の右辺に置くとモジュール読込で評価されて落ちます．`fun` の本体か，遅延されるコンテキストに置いてください．
+
+値のプレースホルダ (e.g. モノイドの `empty`) は無害な値にしておき，未実装の検出は `combine` など関数側の `todo` に任せます．(第10章)
+
+## テストの書き方
+
+`lib/Test.sml` がテストの実行基盤です．各 `*Test.sml` はロード時に `Test.register` で登録し，`Main.sml` (MLton) または `nj-test` / `nj-answers` (SML/NJ) 経由で `Test.run ()` が実行されます．`Test.register` の登録は `structure` の中に書くようにします．
+
+| API | 用途 |
+| --- | --- |
+| `Test.assertEqual` | 等値型 (`''a`) |
+| `Test.assertEqualBy` | `real`，`:>` で隠した型など |
+| `Test.forAll` + `lib/Pbt.sml` | 第8章より前のプロパティテスト |
+| 章内の `Gen` / `Prop` | 第8章以降 (`Pbt` とは別実装) |
+
+テスト名は `chNN ...` のように章番号を含めると，`make test CH=ch03` で絞れます．(`CH` はテスト名の部分一致)
+
+## 処理系ごとの注意点
+
+このリポジトリは MLton (`make test`，`build/*.mlb`) と SML/NJ (`nj-test`，`build/*.cm`) の両方でビルドできる状態にします．
+
+### MLton
+
+`build/*.mlb` に `ann "allowExtendedTextConsts true"` (UTF-8 文字列リテラル) を付けています．
+
+既定の `word` は 32bit なので，大きなワード定数は `Word64.word` と注釈して `Pbt.int` の範囲も小さくしています．
+
+### SML/NJ
+
+`lib/lib.cm` は `Library` ではなく `Group` にします．`Library` だと `Stub` / `Test` が include 先から参照できません．
+
+CM は `.sml` 1ファイルにつきトップレベルで `structure` を定義していることを求めます．([テストの書き方](#テストの書き方))
+
+## 検証
+
+PR の前に次を通します．CI も同じです．
+
+```bash
+nix develop --command make answers
+nix develop --command make test
+nix develop --command make nj-answers
+nix develop --command make nj-test
+```
+
+`answers` / `nj-answers` は全テストの `ok` を期待します．`test` / `nj-test` は `FAIL` が無いことを期待します．演習側の未実装項目は `todo` 表示で問題ありません．
+
+CI のワークフローは [`.github/workflows/fp-in-sml.yml`](../../.github/workflows/fp-in-sml.yml) にあります．
+
+## 整形
+
+[`make fmt`](../Makefile) でコードを整形します．CI には含まれません．
+
+対象は `build/exercises.mlb` と `build/answers.mlb` に列挙された `.sig` / `.sml` です．`.mlb` に未登録のものは対象外です．`smlfmt --force` で上書きしています．
+
+`SMLFMT` 変数でコマンドを上書きできます．

--- a/fp-in-sml/docs/sml-primer.md
+++ b/fp-in-sml/docs/sml-primer.md
@@ -1,0 +1,447 @@
+# Standard ML 入門
+
+この文書では，SML の文法・型・モジュールの仕組みを簡単にまとめています．
+
+演習の進め方は [`README.md`](../README.md) を参照してください．コード片は REPL (`make repl`) に貼り付けて，その場で試せます．
+
+## 目次
+
+- [値・束縛・関数](#値束縛関数)
+- [型](#型)
+- [datatype とパターンマッチ](#datatype-とパターンマッチ)
+- [再帰と末尾再帰](#再帰と末尾再帰)
+- [例外](#例外)
+- [ref と可変性](#ref-と可変性)
+- [Value Restriction](#value-restriction)
+- [モジュールシステム](#モジュールシステム)
+- [等値型](#等値型)
+- [よく使う標準ライブラリ](#よく使う標準ライブラリ)
+
+## 値・束縛・関数
+
+値は `val` で名前に束縛し，関数は `fun` で定義します．無名関数は `fn ... => ...` と書きます．
+
+```sml
+val x = 1 + 2                (* 3 : int *)
+val name = "ml"              (* "ml" : string *)
+
+fun square n = n * n         (* square : int -> int *)
+val inc = fn n => n + 1      (* inc : int -> int *)
+```
+
+局所的な束縛は `let ... in ... end` の中に書きます．`in` の前に置いた補助定義は外から見えません．
+
+```sml
+val y =
+  let
+    val a = 10
+    val b = 20
+  in
+    a + b
+  end
+```
+
+宣言の場合は `local ... in ... end` を使います．
+
+```sml
+local
+  val a = 10
+  val b = 20
+in
+  val y' = a + b
+end
+```
+
+関数適用は `f x` のように書きます．括弧は要りません．
+
+`f (x, y)` は，引数を2つ渡しているのではなく，タプル `(x, y)` を1つ渡しています．
+
+複数の引数はタプルでまとめて渡すか，カリー化して1つずつ渡すかを選べます．カリー化した関数は引数を途中まで与えて新しい関数を作れます (部分適用)．
+
+```sml
+fun add (a, b) = a + b   (* add : int * int -> int *)
+val r1 = add (3, 4)
+
+fun add2 a b = a + b     (* add2 : int -> int -> int *)
+val inc = add2 1         (* inc : int -> int *)
+val r2 = inc 5
+```
+
+中置演算子は `op` を付ければ普通の関数として扱えます．
+
+逆に自作の関数を中置演算にしたいときは `infix` (右結合なら `infixr`，数字は優先順位) で宣言します．
+
+```sml
+val add = op +
+val r = add (3, 4)       (* 7 *)
+
+infix 6 plus
+fun a plus b = a + b
+val n = 3 plus 4         (* 7 *)
+```
+
+論理積と論理和は `andalso` や `orelse` で書きます．どちらも左側だけで結果が決まれば右側を評価せず短絡します．
+
+```sml
+fun inRange n = n > 0 andalso n < 10
+```
+
+## 型
+
+主な型は次の通りです．
+
+- 基本型：`int`，`real` (浮動小数)，`bool`，`char`，`string`，`unit` (値は `()` のみ)
+- タプル：`int * string`，レコード: `{name: string, age: int}`
+- リスト：`int list` (`[1, 2, 3]`，空は `[]`，先頭への追加は `::`，連結は `@`)
+- 関数：`'a -> 'b`
+
+`'a` は多相の型変数で，任意の型を表します．たとえば `length : 'a list -> int` は，要素の型によらずどんなリストにも使えます．
+
+```sml
+val xs : int list = [1, 2, 3]
+val ys = 0 :: xs              (* [0, 1, 2, 3]．:: は先頭に1要素を付ける *)
+val zs = [1, 2] @ [3, 4]      (* [1, 2, 3, 4]．@ はリスト同士を連結する *)
+val pair : int * bool = (1, true)
+```
+
+`type` で既存の型に別名を付けられます．たとえば `type point = int * int` と書くと，以降 `point` を `int * int` の代わりに使えます (中身は同じ型です)．
+
+型注釈は `式 : 型` の形か，引数に `(n : int)` のように書きます．普段は型推論に任せて，必要なときにだけ書くのが一般的です．
+
+## datatype とパターンマッチ
+
+代数的データ型 (直和型) は `datatype` で定義します．
+
+```sml
+datatype color = Red | Green | Blue    (* 列挙 *)
+
+datatype 'a tree =
+    Leaf
+  | Node of 'a tree * 'a * 'a tree     (* 再帰的なデータ型 *)
+```
+
+`option` (値があるか無いか) のように，よく使う型は標準ライブラリに定義済みです．
+
+```sml
+(* datatype 'a option = NONE | SOME of 'a *)
+val x = SOME 42
+val y = NONE
+```
+
+これらの値は，`case ... of` 式や `fun` でパターンマッチして分解します．
+
+```sml
+fun describe c =
+    case c of
+        Red => "あつい"
+      | Green => "ちょうどいい"
+      | Blue => "さむい"
+
+(* 関数を複数の節に分けてマッチする，再帰でリストを畳む例 *)
+fun sum [] = 0
+  | sum (x :: rest) = x + sum rest
+
+(* as を使うとマッチした全体に別名を付けることができる *)
+fun firstTwo (xs as (a :: b :: _)) = SOME (a, b, xs)
+  | firstTwo _ = NONE
+```
+
+パターンが網羅されていないと，コンパイラが警告してくれます．`_` は何にでもマッチするワイルドカードです．
+
+レコードもパターンマッチで中身を取り出せます．
+
+```sml
+val p = {name = "Alice", age = 20}
+
+(* n = "Alice", a = 20 として束縛する *)
+val {name = n, age = a} = p
+
+(* 必要なフィールドだけ束縛する *)
+fun greet {name, age} = "Hello " ^ name
+val msg = greet p
+
+(* #フィールド名 で直接アクセスもできる *)
+val nm = #name p
+```
+
+## 再帰と末尾再帰
+
+繰り返しは基本的に再帰で書きます．スタックを消費しないように，末尾再帰の形にするのが定石です．
+
+```sml
+(* 末尾再帰でない (呼び出しの後に + が残る) *)
+fun lengthBad [] = 0
+  | lengthBad (_ :: t) = 1 + lengthBad t
+
+(* 末尾再帰 (acc に積んでいく) *)
+fun length xs =
+    let
+      fun go (acc, []) = acc
+        | go (acc, _ :: t) = go (acc + 1, t)
+    in
+      go (0, xs)
+    end
+```
+
+互いに呼び合う関数は，`and` でつないで同時に定義します (相互再帰)．
+
+```sml
+fun isEven 0 = true
+  | isEven n = isOdd (n - 1)
+and isOdd 0 = false
+  | isOdd n = isEven (n - 1)
+```
+
+## 例外
+
+エラー処理に例外を使うことができます．
+
+```sml
+exception EmptyList
+exception BadArg of string          (* 値を持たせることもできる *)
+
+val e = EmptyList                   (* 例外も値 (exn 型) として扱える *)
+
+fun head [] = raise EmptyList
+  | head (x :: _) = x
+
+val safe = head [] handle EmptyList => ~1   (* handle で捕捉する．~1 は -1 *)
+```
+
+## ref と可変性
+
+可変なセルを `ref` で作れます．
+
+```sml
+val counter = ref 0                (* int ref *)
+val () = counter := !counter + 1   (* := で代入し，! で中身を参照する *)
+val now = !counter                 (* 1 *)
+```
+
+セミコロンで `(e1; e2; e3)` のように並べることで複数の式を順に評価できます．最後の式の値が全体の値になります．
+
+`ref` の更新や `print` のように，副作用を起こす処理を並べて使います．
+
+```sml
+val () = (
+  counter := !counter + 1;
+  print "Updated!\n"
+)
+```
+
+while ... do ... 式で副作用を伴うループ処理が書けます．条件式が真である間，本体の式を繰り返し評価します (ループ全体の値は unit)．
+
+```sml
+val i = ref 0
+val () =
+  while !i < 3 do (
+    print ("count: " ^ Int.toString (!i) ^ "\n");
+    i := !i + 1
+  )
+
+(* これと等価 *)
+val () =
+  let
+    fun loop () =
+      if !i < 3 then (
+        print ("count: " ^ Int.toString (!i) ^ "\n");
+        i := !i + 1;
+        loop ()
+      ) else ()
+  in
+    loop ()
+  end
+```
+
+パフォーマンスの面で有利になる局面はありますが，こうした可変な状態やループ処理はグローバルに見せず `let` などで局所的に閉じ込めるのが定石です．
+
+```sml
+(* 外から見ると普通の関数 int -> int *)
+fun sumN n =
+  let
+    val i = ref 1
+    val acc = ref 0
+  in
+    while !i <= n do (
+      acc := !acc + !i;
+      i := !i + 1
+    );
+    !acc
+  end
+
+val total = sumN 10   (* 55 *)
+```
+
+## Value Restriction
+
+副作用と多相性の組み合わせで型安全性が崩れるのを防ぐため，束縛の右辺が構文として値 (定数や `fn` など) でない場合，型変数が多相型 (汎用的な `'a`) に一般化されません．
+
+```sml
+val r = ref []                  (* 型変数が一般化されず，未確定のまま *)
+val r : int list ref = ref []   (* 注釈で型を固定すればよい *)
+```
+
+`ref` を使っていなくても，右辺が関数適用とみなされて一般化されないことがあります．多相性を保ちたいときは，`fn` で包んで構文上の値にします．
+
+```sml
+(* 一般化されず，型変数がダミー型に固定されてしまう *)
+val id = List.rev o List.rev
+
+(* fn で明示的に引数を取る形にする *)
+val id = fn xs => (List.rev o List.rev) xs
+```
+
+一般化できなかった束縛をエラーにするか警告で済ますかは処理系によります．MLton と SML/NJ はどちらも警告に留め，互換性のないダミー型に固定して続行します．
+
+## モジュールシステム
+
+モジュールシステムは SML の大きな強みです．signature, structure, functor の3つを駆使します．
+
+### signature について
+
+signature はモジュールの型にあたります．公開する型や値を並べたものです．
+
+```sml
+signature STACK =
+sig
+  type 'a t                       (* 抽象型，中身は見せない *)
+  val empty : 'a t
+  val push  : 'a -> 'a t -> 'a t
+  val pop   : 'a t -> ('a * 'a t) option
+end
+```
+
+### structure について
+
+structure は signature に対応する具体的な実装です．
+
+```sml
+structure ListStack : STACK =
+struct
+  type 'a t = 'a list
+  val empty = []
+  fun push x s = x :: s
+  fun pop [] = NONE
+    | pop (x :: s) = SOME (x, s)
+end
+```
+
+structure に含まれる名前には `ListStack.empty` のようにアクセスします．
+
+`open S` と書いて展開すると `S.foo` を `foo` と修飾なしで使えるようになります．
+
+```sml
+structure M =
+struct
+  val base = 10
+  fun double x = x * 2
+end
+
+structure UseM =
+struct
+  open M    (* 以降 base と double を M. なしで使える *)
+  val n = double base
+end
+
+local
+  open M    (* local の外に base や double といった名前を漏らさないように使う *)
+in
+  val n = double base
+end
+```
+
+### 透明な signature `:` と不透明な signature `:>`
+
+signature の当て方が2通りあります．型の正体を隠すかどうかが違います．
+
+- `structure S : SIG` ... signature に書いた成分だけを公開しますが `type 'a t` のような抽象型の実装は外からも見えます
+- `structure S :> SIG` ... signature で `type 'a t` と宣言だけした抽象型はその正体が隠れます
+
+```sml
+structure ListStack : STACK =
+struct
+  type 'a t = 'a list
+  (* ... *)
+end
+val xs : int ListStack.t = [1, 2, 3]  (* 外の list と互換性がある *)
+
+structure MyStack :> STACK =
+struct
+  type 'a t = 'a list
+  (* ... *)
+end
+val ys : int MyStack.t = [1, 2, 3]    (* S.t の正体が隠蔽されており型エラー *)
+```
+
+`:>` で隠した型のうち一部だけを公開したいときは，signature に `where type T = ...` を付けます．複数の型を持つ signature で，内部でのみ利用する型は隠しつつも外部とやりとりする型だけ見せたい場合に使います．
+
+### functor について
+ 
+functor はモジュールの関数です．あるモジュールを受け取って別のモジュールを組み立てます．
+
+```sml
+signature ADD =
+sig
+  type t
+  val zero : t
+  val add : t * t -> t
+end
+
+functor MkPair (A : ADD) =
+struct
+  type t = A.t * A.t
+  val zero = (A.zero, A.zero)
+  fun add ((a1, b1), (a2, b2)) = (A.add (a1, a2), A.add (b1, b2))
+end
+```
+
+引数には structure だけでなく，型そのものを書くこともできます．`(type s)` と書くと型 `s` を受け取る functor になり `(type s = int)` のように型を渡せます．
+
+```sml
+functor MkBox (type s) =
+struct
+  type t = s
+  val items : s list ref = ref []
+end
+
+structure IntBox = MkBox (type s = int)
+```
+
+## 等値型
+
+`=` で比較できる型を等値型とよびます．型変数では `''a` のように表されます．
+
+`int` や `string` や `bool` やタプルやリストなどは等値型ですが `real` や関数は等値型ではありません．
+
+```sml
+(* real は等値型でないので 1.0 = 1.0 は型エラー，比較には Real.== を使う *)
+val b1 = Real.== (1.0, 1.0)
+
+fun member (_, []) = false
+  | member (x, y :: ys) = x = y orelse member (x, ys)
+(* member : ''a * ''a list -> bool *)
+```
+
+構成要素がすべて等値型であれば datatype も等値型になります．
+
+```sml
+datatype color = Red | Green
+val b2 = Red = Green               (* 等値型なので OK *)
+
+datatype t = F of int -> int
+(* F f = F g は型エラー，関数を含むので等値型でない *)
+```
+
+signature で抽象型に等値比較を要求したいときは，`type` の代わりに `eqtype` と宣言します．
+
+## よく使う標準ライブラリ
+
+| ライブラリ | 利用例 |
+| --- | --- |
+| `List.map` / `List.filter` / `List.foldl` / `List.foldr` | `List.foldl (op +) 0 [1, 2, 3]` |
+| `List.rev` / `List.length` / `List.nth` / `List.tabulate` | `List.tabulate (3, fn i => i)` = `[0, 1, 2]` |
+| `Option.map` / `Option.getOpt` / `Option.valOf` | `Option.getOpt (NONE, 0)` = `0` |
+| `Int.toString` / `Int.compare` | `Int.toString 42` |
+| `^` (文字列の連結) / `String.size` / `concat` | `"a" ^ "b"`，`concat ["a", "b"]` |
+| `f o g` (関数合成) | `(Math.sqrt o real) 9` = `3.0` |
+| `print` | `print "hi\n"` |

--- a/fp-in-sml/flake.lock
+++ b/fp-in-sml/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/fp-in-sml/flake.nix
+++ b/fp-in-sml/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "fp-in-sml: Functional Programming in Scala の演習を Standard ML で解く";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = [
+            pkgs.mlton
+            pkgs.smlnj
+            pkgs.smlfmt
+            pkgs.millet
+            pkgs.rlwrap
+            pkgs.gnumake
+          ];
+        };
+      });
+    };
+}

--- a/fp-in-sml/lib/Pbt.sml
+++ b/fp-in-sml/lib/Pbt.sml
@@ -1,0 +1,104 @@
+(* プロパティベーステストの基盤です．
+ *
+ * - 第8章で `Gen`/`Prop` を自作するより前から，第3章などの差分テストでランダム入力を生成するために提供します．
+ * - 乱数源の `Pbt.Rng` も自己完結で，第6章の演習 `Rng` とは別物です．
+ *
+ * `'a gen` は乱数状態を受け取って値と次の状態を返す，状態渡しの関数です．
+ *)
+structure Pbt :>
+sig
+  type 'a gen
+
+  val int: int gen
+  val bool: bool gen
+  val char: char gen
+  val intRange: int * int -> int gen
+
+  val map: ('a -> 'b) -> 'a gen -> 'b gen
+  val bind: 'a gen -> ('a -> 'b gen) -> 'b gen
+  val pair: 'a gen * 'b gen -> ('a * 'b) gen
+  val list: 'a gen -> 'a list gen
+
+  (* pred を多数の乱入力で試し，最初に偽となった入力を返す．無ければ NONE を返す． *)
+  val findCounterexample: 'a gen -> ('a -> bool) -> 'a option
+end =
+struct
+  type seed = Word64.word
+  type 'a gen = seed -> 'a * seed
+
+  (* 線形合同法 (Knuth/MMIX の定数) で次の状態へ． *)
+  fun step (s: seed) : seed =
+    Word64.+ (Word64.* (s, 0w6364136223846793005), 0w1442695040888963407)
+
+  (* 0 .. 2^30-1 の非負整数です．31bit Int でも安全な範囲です． *)
+  fun rawNat (s: seed) : int * seed =
+    let
+      val s' = step s
+      val v = Word64.toInt (Word64.andb (Word64.>> (s', 0w34), 0wx3FFFFFFF))
+    in
+      (v, s')
+    end
+
+  (* テストでの算術が既定の Int (MLton は 32bit) を溢れさせないよう小さめの範囲にします． *)
+  fun int s =
+    let val (v, s') = rawNat s
+    in (v mod 2001 - 1000, s')
+    end (* [-1000, 1000] *)
+
+  fun bool s =
+    let val (v, s') = rawNat s
+    in (v mod 2 = 0, s')
+    end
+
+  fun intRange (lo, hi) s =
+    if hi <= lo then (lo, step s)
+    else let val (v, s') = rawNat s in (lo + v mod (hi - lo + 1), s') end
+
+  fun char s =
+    let val (v, s') = intRange (97, 122) s
+    in (Char.chr v, s')
+    end
+
+  fun map f g =
+    fn s => let val (a, s') = g s in (f a, s') end
+
+  fun bind g k =
+    fn s => let val (a, s') = g s in k a s' end
+
+  fun pair (ga, gb) =
+    fn s =>
+      let
+        val (a, s1) = ga s
+        val (b, s2) = gb s1
+      in
+        ((a, b), s2)
+      end
+
+  fun list g =
+    fn s =>
+      let
+        val (n, s0) = intRange (0, 16) s
+        fun loop (0, st, acc) = (List.rev acc, st)
+          | loop (k, st, acc) =
+              let val (x, st') = g st
+              in loop (k - 1, st', x :: acc)
+              end
+      in
+        loop (n, s0, [])
+      end
+
+  (* 再現性のための固定シードです．MLton の既定 word は 32 bit なので型注釈が必須です． *)
+  val initialSeed: seed = 0wx2545F4914F6CDD1D
+
+  fun findCounterexample g pred =
+    let
+      val numTests = 200
+      fun loop (0, _) = NONE
+        | loop (k, s) =
+            let val (x, s') = g s
+            in if pred x then loop (k - 1, s') else SOME x
+            end
+    in
+      loop (numTests, initialSeed)
+    end
+end

--- a/fp-in-sml/lib/Stub.sml
+++ b/fp-in-sml/lib/Stub.sml
@@ -1,0 +1,11 @@
+(* 未実装箇所を表すプレースホルダです．
+ * 演習 (exercises) では，本体にある Stub.todo () を置き換える形で実装していきます．
+ * Test は，例外 `Stub.Todo` を捕捉し，本物の失敗 (FAIL) とは別の未実装 (todo) として表示します． *)
+structure Stub =
+struct
+  exception Todo
+
+  (* Stub.todo () は任意の型に単一化される．
+   * 評価されると Todo を投げる． *)
+  fun todo () = raise Todo
+end

--- a/fp-in-sml/lib/Test.sml
+++ b/fp-in-sml/lib/Test.sml
@@ -1,0 +1,92 @@
+(* 軽量なテスト実行基盤です．
+ *
+ * - 各テストファイルはロード時に `Test.register name body` でテストを登録します．
+ * - `Main.sml` の `Test.run ()` が登録順に実行し，結果を集計して終了コードを返します．
+ * - アサーション:
+ *     assertEqual    → 等値型 (''a) 同士の比較
+ *     assertEqualBy  → 非等値型 (real / 関数 / :> で隠した型 / State / LazyList など) 向けに eq と show を明示
+ *     assertBool     → 真偽値の検証
+ *     expectExn      → 例外が投げられたことの確認
+ *     forAll         → Pbt のジェネレータで乱入力プロパティ検査 (反例を表示)
+ * - 未実装を表す例外 `Stub.Todo` は todo (未実装) として FAIL とは区別して表示します．
+ *)
+structure Test:
+sig
+  val assertBool: string -> bool -> unit
+  val assertEqual: ''a * ''a -> unit
+  val assertEqualBy: {eq: 'a * 'a -> bool, show: 'a -> string}
+                     -> 'a * 'a
+                     -> unit
+  val expectExn: (unit -> 'a) -> unit
+  val forAll: ('a -> string) -> 'a Pbt.gen -> ('a -> bool) -> unit
+  val register: string -> (unit -> unit) -> unit
+  val run: unit -> OS.Process.status
+end =
+struct
+  exception Assertion of string
+
+  fun assertBool msg b =
+    if b then () else raise Assertion msg
+
+  fun assertEqual (a, b) =
+    if a = b then () else raise Assertion "値が一致しません"
+
+  fun assertEqualBy {eq, show} (a, b) =
+    if eq (a, b) then ()
+    else raise Assertion ("不一致: " ^ show a ^ " <> " ^ show b)
+
+  fun expectExn thunk =
+    ( ignore (thunk ())
+    ; raise Assertion "例外が送出されませんでした"
+    )
+    handle
+      Stub.Todo => raise Stub.Todo
+    | Assertion m => raise Assertion m
+    | _ => () (* 期待どおり何らかの例外 *)
+
+  fun forAll show g pred =
+    case Pbt.findCounterexample g pred of
+      NONE => ()
+    | SOME x => raise Assertion ("反例: " ^ show x)
+
+  val tests: (string * (unit -> unit)) list ref = ref []
+
+  fun register name body =
+    tests := (name, body) :: !tests
+
+  fun run () =
+    let
+      val all = List.rev (!tests)
+      val args = CommandLine.arguments ()
+      fun selected name =
+        null args orelse List.exists (fn a => String.isSubstring a name) args
+      val chosen = List.filter (fn (n, _) => selected n) all
+
+      val nPass = ref 0
+      val nFail = ref 0
+      val nTodo = ref 0
+
+      fun runOne (name, body) =
+        (body (); nPass := !nPass + 1; print ("  ok    " ^ name ^ "\n"))
+        handle
+          Stub.Todo => (nTodo := !nTodo + 1; print ("  todo  " ^ name ^ "\n"))
+        | Assertion m =>
+            (nFail := !nFail + 1; print ("  FAIL  " ^ name ^ ": " ^ m ^ "\n"))
+        | e =>
+            ( nFail := !nFail + 1
+            ; print ("  ERROR " ^ name ^ ": " ^ exnMessage e ^ "\n")
+            )
+    in
+      List.app runOne chosen;
+      print (concat
+        [ "\n"
+        , Int.toString (!nPass)
+        , " ok, "
+        , Int.toString (!nFail)
+        , " failed, "
+        , Int.toString (!nTodo)
+        , " todo\n"
+        ]);
+      if !nFail = 0 then OS.Process.success else OS.Process.failure
+    end
+end

--- a/fp-in-sml/lib/lib.cm
+++ b/fp-in-sml/lib/lib.cm
@@ -1,0 +1,7 @@
+(* SML/NJ (CM) で最初に読み込むグループです．
+ * build/*.cm が include してから再エクスポートできるよう Library ではなく Group にしています． *)
+Group is
+  $/basis.cm
+  Stub.sml
+  Pbt.sml
+  Test.sml

--- a/fp-in-sml/lib/lib.mlb
+++ b/fp-in-sml/lib/lib.mlb
@@ -1,0 +1,8 @@
+$(SML_LIB)/basis/basis.mlb
+
+(* MLton で日本語 (non ascii) を使うために有効化 *)
+ann "allowExtendedTextConsts true" in
+  Stub.sml
+  Pbt.sml
+  Test.sml
+end

--- a/fp-in-sml/millet.toml
+++ b/fp-in-sml/millet.toml
@@ -1,0 +1,7 @@
+# LSP (Millet) の設定．
+# 既定では演習側のビルドを解析対象にする．
+# 解答側を見たいときは root を build/answers.mlb に変更する．
+version = 1
+
+[workspace]
+root = "build/exercises.mlb"

--- a/fp-in-sml/src/ch02_gettingstarted/INTRO.sig
+++ b/fp-in-sml/src/ch02_gettingstarted/INTRO.sig
@@ -1,0 +1,19 @@
+(* 第2章 関数型プログラミングへの準備．
+ * 高階関数・カリー化・関数合成といった基礎を SML で確認する． *)
+signature INTRO =
+sig
+  (* n 番目のフィボナッチ数 (fib 0 = 0, fib 1 = 1)． *)
+  val fib: int -> int
+
+  (* 比較関数 ordered に照らして列が昇順かを判定する． *)
+  val isSorted: 'a list * ('a * 'a -> bool) -> bool
+
+  (* タプル2引数の関数をカリー化する． *)
+  val curry: ('a * 'b -> 'c) -> 'a -> 'b -> 'c
+
+  (* curry の逆． *)
+  val uncurry: ('a -> 'b -> 'c) -> 'a * 'b -> 'c
+
+  (* 2つの関数を合成する (compose f g = fn x => f (g x))． *)
+  val compose: ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c
+end

--- a/fp-in-sml/src/ch02_gettingstarted/answers/Intro.sml
+++ b/fp-in-sml/src/ch02_gettingstarted/answers/Intro.sml
@@ -1,0 +1,23 @@
+(* 第2章 解答例． *)
+structure Intro: INTRO =
+struct
+  fun fib n =
+    let
+      fun go (0, prev, _) = prev
+        | go (k, prev, cur) =
+            go (k - 1, cur, prev + cur)
+    in
+      go (n, 0, 1)
+    end
+
+  fun isSorted (xs, ordered) =
+    case xs of
+      a :: (rest as b :: _) => ordered (a, b) andalso isSorted (rest, ordered)
+    | _ => true
+
+  fun curry f a b = f (a, b)
+
+  fun uncurry f (a, b) = f a b
+
+  fun compose f g = f o g
+end

--- a/fp-in-sml/src/ch02_gettingstarted/exercises/Intro.sml
+++ b/fp-in-sml/src/ch02_gettingstarted/exercises/Intro.sml
@@ -1,0 +1,18 @@
+(* 第2章 演習．各関数の本体を Stub.todo () から置き換えて実装する． *)
+structure Intro: INTRO =
+struct
+  (* Exercise 2.1: 末尾再帰で n 番目のフィボナッチ数を求めよ． *)
+  fun fib n = Stub.todo ()
+
+  (* Exercise 2.2: ordered で隣接要素を比較し，列が昇順かを判定せよ． *)
+  fun isSorted (xs, ordered) = Stub.todo ()
+
+  (* Exercise 2.3: curry を実装せよ． *)
+  fun curry f = Stub.todo ()
+
+  (* Exercise 2.4: uncurry を実装せよ． *)
+  fun uncurry f = Stub.todo ()
+
+  (* Exercise 2.5: compose を実装せよ． *)
+  fun compose f g = Stub.todo ()
+end

--- a/fp-in-sml/src/ch03_datastructures/MY_LIST.sig
+++ b/fp-in-sml/src/ch03_datastructures/MY_LIST.sig
@@ -1,0 +1,35 @@
+(* 第3章 関数型データ構造: 単方向リスト．
+ * 本書にならい Basis の list ではなく独自の datatype を定義する．
+ * fromList / toList は Basis list との橋渡し (テストや REPL 用の補助)． *)
+signature MY_LIST =
+sig
+  datatype 'a t = Nil | Cons of 'a * 'a t
+
+  (* 補助 (演習対象ではない) *)
+  val fromList: 'a list -> 'a t
+  val toList: 'a t -> 'a list
+
+  val tail: 'a t -> 'a t
+  val setHead: 'a -> 'a t -> 'a t
+  val drop: int -> 'a t -> 'a t
+  val dropWhile: ('a -> bool) -> 'a t -> 'a t
+  val init: 'a t -> 'a t
+
+  val length: 'a t -> int
+  val foldRight: 'a t -> 'b -> ('a * 'b -> 'b) -> 'b
+  val foldLeft: 'a t -> 'b -> ('a * 'b -> 'b) -> 'b
+
+  val sum: int t -> int
+  val product: real t -> real
+  val reverse: 'a t -> 'a t
+  val append: 'a t -> 'a t -> 'a t
+  val concat: 'a t t -> 'a t
+
+  val map: ('a -> 'b) -> 'a t -> 'b t
+  val filter: ('a -> bool) -> 'a t -> 'a t
+  val flatMap: ('a -> 'b t) -> 'a t -> 'b t
+  val zipWith: ('a * 'b -> 'c) -> 'a t -> 'b t -> 'c t
+
+  (* sup が sub を部分列として含むか． *)
+  val hasSubsequence: ''a t -> ''a t -> bool
+end

--- a/fp-in-sml/src/ch03_datastructures/TREE.sig
+++ b/fp-in-sml/src/ch03_datastructures/TREE.sig
@@ -1,0 +1,12 @@
+(* 第3章 二分木．葉に値を持つ Leaf と，左右の部分木を持つ Branch． *)
+signature TREE =
+sig
+  datatype 'a t = Leaf of 'a | Branch of 'a t * 'a t
+
+  val size: 'a t -> int
+  val depth: 'a t -> int
+  val map: ('a -> 'b) -> 'a t -> 'b t
+  (* 葉を g で，枝を combine で畳む一般化． *)
+  val fold: ('a -> 'b) -> ('b * 'b -> 'b) -> 'a t -> 'b
+  val maximum: int t -> int
+end

--- a/fp-in-sml/src/ch03_datastructures/answers/MyList.sml
+++ b/fp-in-sml/src/ch03_datastructures/answers/MyList.sml
@@ -1,0 +1,93 @@
+(* 第3章 解答例 (MyList)． *)
+structure MyList: MY_LIST =
+struct
+  datatype 'a t = Nil | Cons of 'a * 'a t
+
+  fun fromList xs =
+    List.foldr (fn (x, acc) => Cons (x, acc)) Nil xs
+
+  fun toList Nil = []
+    | toList (Cons (x, xs)) = x :: toList xs
+
+  exception Empty
+
+  fun tail Nil = raise Empty
+    | tail (Cons (_, xs)) = xs
+
+  fun setHead x Nil = raise Empty
+    | setHead x (Cons (_, xs)) = Cons (x, xs)
+
+  fun drop n xs =
+    if n <= 0 then
+      xs
+    else
+      case xs of
+        Nil => Nil
+      | Cons (_, rest) => drop (n - 1) rest
+
+  fun dropWhile p Nil = Nil
+    | dropWhile p (xs as Cons (x, rest)) =
+        if p x then dropWhile p rest else xs
+
+  fun init Nil = raise Empty
+    | init (Cons (_, Nil)) = Nil
+    | init (Cons (x, rest)) =
+        Cons (x, init rest)
+
+  fun foldRight Nil z _ = z
+    | foldRight (Cons (x, xs)) z f =
+        f (x, foldRight xs z f)
+
+  fun foldLeft xs z f =
+    let
+      fun go (acc, Nil) = acc
+        | go (acc, Cons (x, rest)) =
+            go (f (x, acc), rest)
+    in
+      go (z, xs)
+    end
+
+  fun length xs =
+    foldLeft xs 0 (fn (_, acc) => acc + 1)
+
+  fun sum xs =
+    foldLeft xs 0 (op+)
+
+  fun product xs =
+    foldLeft xs 1.0 (op*)
+
+  fun reverse xs =
+    foldLeft xs Nil (fn (x, acc) => Cons (x, acc))
+
+  fun append xs ys =
+    foldRight xs ys (fn (x, acc) => Cons (x, acc))
+
+  fun concat xss =
+    foldRight xss Nil (fn (xs, acc) => append xs acc)
+
+  fun map f xs =
+    foldRight xs Nil (fn (x, acc) => Cons (f x, acc))
+
+  fun filter p xs =
+    foldRight xs Nil (fn (x, acc) => if p x then Cons (x, acc) else acc)
+
+  fun flatMap f xs =
+    concat (map f xs)
+
+  fun zipWith f (Cons (x, xs)) (Cons (y, ys)) =
+        Cons (f (x, y), zipWith f xs ys)
+    | zipWith _ _ _ = Nil
+
+  fun startsWith _ Nil = true
+    | startsWith Nil _ = false
+    | startsWith (Cons (x, xs)) (Cons (y, ys)) =
+        x = y andalso startsWith xs ys
+
+  fun hasSubsequence sup sub =
+    case sub of
+      Nil => true
+    | _ =>
+        (case sup of
+           Nil => false
+         | Cons (_, rest) => startsWith sup sub orelse hasSubsequence rest sub)
+end

--- a/fp-in-sml/src/ch03_datastructures/answers/Tree.sml
+++ b/fp-in-sml/src/ch03_datastructures/answers/Tree.sml
@@ -1,0 +1,22 @@
+(* 第3章 解答例 (Tree)． *)
+structure Tree: TREE =
+struct
+  datatype 'a t = Leaf of 'a | Branch of 'a t * 'a t
+
+  fun fold g combine (Leaf a) = g a
+    | fold g combine (Branch (l, r)) =
+        combine (fold g combine l, fold g combine r)
+
+  (* size/depth/map/maximum はすべて fold だけで表せる． *)
+  fun size t =
+    fold (fn _ => 1) (fn (l, r) => 1 + l + r) t
+
+  fun depth t =
+    fold (fn _ => 0) (fn (l, r) => 1 + Int.max (l, r)) t
+
+  fun map f t =
+    fold (fn a => Leaf (f a)) Branch t
+
+  fun maximum t =
+    fold (fn a => a) Int.max t
+end

--- a/fp-in-sml/src/ch03_datastructures/exercises/MyList.sml
+++ b/fp-in-sml/src/ch03_datastructures/exercises/MyList.sml
@@ -1,0 +1,64 @@
+(* 第3章 演習 (MyList)．
+ * fromList / toList は補助なので実装済み．残りの Stub.todo を置き換えていく． *)
+structure MyList: MY_LIST =
+struct
+  datatype 'a t = Nil | Cons of 'a * 'a t
+
+  fun fromList xs =
+    List.foldr (fn (x, acc) => Cons (x, acc)) Nil xs
+
+  fun toList Nil = []
+    | toList (Cons (x, xs)) = x :: toList xs
+
+  (* Exercise 3.2: 先頭を除いたリストを返せ (空なら例外)． *)
+  fun tail xs = Stub.todo ()
+
+  (* Exercise 3.3: 先頭を差し替えたリストを返せ． *)
+  fun setHead x xs = Stub.todo ()
+
+  (* Exercise 3.4: 先頭から n 個落とせ． *)
+  fun drop n xs = Stub.todo ()
+
+  (* Exercise 3.5: 条件を満たす間だけ先頭から落とせ． *)
+  fun dropWhile p xs = Stub.todo ()
+
+  (* Exercise 3.6: 末尾要素を除いたリストを返せ． *)
+  fun init xs = Stub.todo ()
+
+  (* Exercise 3.x: foldRight で長さを数えられるよう，まず foldRight を実装せよ． *)
+  fun foldRight xs z f = Stub.todo ()
+
+  (* Exercise 3.10: 末尾再帰の foldLeft を実装せよ． *)
+  fun foldLeft xs z f = Stub.todo ()
+
+  (* Exercise 3.9: foldRight か foldLeft で長さを数えよ． *)
+  fun length xs = Stub.todo ()
+
+  fun sum xs = Stub.todo ()
+
+  fun product xs = Stub.todo ()
+
+  (* Exercise 3.12: reverse を foldLeft で実装せよ． *)
+  fun reverse xs = Stub.todo ()
+
+  (* Exercise 3.14: append を fold で実装せよ． *)
+  fun append xs ys = Stub.todo ()
+
+  (* Exercise 3.15: リストのリストを連結せよ． *)
+  fun concat xss = Stub.todo ()
+
+  (* Exercise 3.18: map を実装せよ． *)
+  fun map f xs = Stub.todo ()
+
+  (* Exercise 3.19: filter を実装せよ． *)
+  fun filter p xs = Stub.todo ()
+
+  (* Exercise 3.20: flatMap を実装せよ． *)
+  fun flatMap f xs = Stub.todo ()
+
+  (* Exercise 3.23: zipWith を実装せよ． *)
+  fun zipWith f xs ys = Stub.todo ()
+
+  (* Exercise 3.24: hasSubsequence を実装せよ． *)
+  fun hasSubsequence sup sub = Stub.todo ()
+end

--- a/fp-in-sml/src/ch03_datastructures/exercises/Tree.sml
+++ b/fp-in-sml/src/ch03_datastructures/exercises/Tree.sml
@@ -1,0 +1,20 @@
+(* 第3章 演習 (Tree)． *)
+structure Tree: TREE =
+struct
+  datatype 'a t = Leaf of 'a | Branch of 'a t * 'a t
+
+  (* Exercise 3.25: 葉と枝の総数を数えよ． *)
+  fun size t = Stub.todo ()
+
+  (* Exercise 3.27: 根から葉までの最大の深さを返せ． *)
+  fun depth t = Stub.todo ()
+
+  (* Exercise 3.28: 各葉に f を適用せよ． *)
+  fun map f t = Stub.todo ()
+
+  (* Exercise 3.29: size / depth / map を一般化する fold を実装せよ． *)
+  fun fold g combine t = Stub.todo ()
+
+  (* Exercise 3.26: int の木の最大値を返せ． *)
+  fun maximum t = Stub.todo ()
+end

--- a/fp-in-sml/src/ch04_errorhandling/EITHER.sig
+++ b/fp-in-sml/src/ch04_errorhandling/EITHER.sig
@@ -1,0 +1,12 @@
+(* 第4章 誤りに理由を付ける: Either．Left が失敗 (理由)，Right が成功． *)
+signature EITHER =
+sig
+  datatype ('e, 'a) t = Left of 'e | Right of 'a
+
+  val map: ('a -> 'b) -> ('e, 'a) t -> ('e, 'b) t
+  val flatMap: ('a -> ('e, 'b) t) -> ('e, 'a) t -> ('e, 'b) t
+  val orElse: ('e, 'a) t -> ('e, 'a) t -> ('e, 'a) t
+  val map2: ('a * 'b -> 'c) -> ('e, 'a) t -> ('e, 'b) t -> ('e, 'c) t
+  val sequence: ('e, 'a) t list -> ('e, 'a list) t
+  val traverse: ('a -> ('e, 'b) t) -> 'a list -> ('e, 'b list) t
+end

--- a/fp-in-sml/src/ch04_errorhandling/MY_OPTION.sig
+++ b/fp-in-sml/src/ch04_errorhandling/MY_OPTION.sig
@@ -1,0 +1,21 @@
+(* 第4章 例外を使わない誤り処理: Option．
+ * Basis の option とは別に自作して，Basis を参照実装に比較する．
+ * 本書の getOrElse / orElse は引数が名前渡し (遅延) だが，ここでは簡潔さのため
+ * 正格 (先に評価) にしている． *)
+signature MY_OPTION =
+sig
+  datatype 'a t = None | Some of 'a
+
+  val map: ('a -> 'b) -> 'a t -> 'b t
+  val getOrElse: 'a t -> 'a -> 'a
+  val flatMap: ('a -> 'b t) -> 'a t -> 'b t
+  val orElse: 'a t -> 'a t -> 'a t
+  val filter: ('a -> bool) -> 'a t -> 'a t
+  val map2: ('a * 'b -> 'c) -> 'a t -> 'b t -> 'c t
+  val sequence: 'a t list -> 'a list t
+  val traverse: ('a -> 'b t) -> 'a list -> 'b list t
+
+  (* Basis option との橋渡し (補助) *)
+  val toOption: 'a t -> 'a option
+  val fromOption: 'a option -> 'a t
+end

--- a/fp-in-sml/src/ch04_errorhandling/answers/Either.sml
+++ b/fp-in-sml/src/ch04_errorhandling/answers/Either.sml
@@ -1,0 +1,24 @@
+(* 第4章 解答例 (Either)． *)
+structure Either: EITHER =
+struct
+  datatype ('e, 'a) t = Left of 'e | Right of 'a
+
+  fun map f (Right a) =
+        Right (f a)
+    | map f (Left e) = Left e
+
+  fun flatMap f (Right a) = f a
+    | flatMap f (Left e) = Left e
+
+  fun orElse (Left _) other = other
+    | orElse right _ = right
+
+  fun map2 f ea eb =
+    flatMap (fn a => map (fn b => f (a, b)) eb) ea
+
+  fun traverse f xs =
+    List.foldr (fn (x, acc) => map2 (op::) (f x) acc) (Right []) xs
+
+  fun sequence es =
+    traverse (fn x => x) es
+end

--- a/fp-in-sml/src/ch04_errorhandling/answers/MyOption.sml
+++ b/fp-in-sml/src/ch04_errorhandling/answers/MyOption.sml
@@ -1,0 +1,37 @@
+(* 第4章 解答例 (MyOption)． *)
+structure MyOption: MY_OPTION =
+struct
+  datatype 'a t = None | Some of 'a
+
+  fun toOption None = NONE
+    | toOption (Some a) = SOME a
+
+  fun fromOption NONE = None
+    | fromOption (SOME a) = Some a
+
+  fun map f None = None
+    | map f (Some a) =
+        Some (f a)
+
+  fun getOrElse None default = default
+    | getOrElse (Some a) _ = a
+
+  fun flatMap f None = None
+    | flatMap f (Some a) = f a
+
+  fun orElse None other = other
+    | orElse some _ = some
+
+  fun filter p None = None
+    | filter p (Some a) =
+        if p a then Some a else None
+
+  fun map2 f oa ob =
+    flatMap (fn a => map (fn b => f (a, b)) ob) oa
+
+  fun traverse f xs =
+    List.foldr (fn (x, acc) => map2 (op::) (f x) acc) (Some []) xs
+
+  fun sequence opts =
+    traverse (fn x => x) opts
+end

--- a/fp-in-sml/src/ch04_errorhandling/exercises/Either.sml
+++ b/fp-in-sml/src/ch04_errorhandling/exercises/Either.sml
@@ -1,0 +1,16 @@
+(* 第4章 演習 (Either)． *)
+structure Either: EITHER =
+struct
+  datatype ('e, 'a) t = Left of 'e | Right of 'a
+
+  (* Exercise 4.6: map / flatMap / orElse / map2 を実装せよ．
+   * いずれも最初に出会った Left を伝播させる． *)
+  fun map f e = Stub.todo ()
+  fun flatMap f e = Stub.todo ()
+  fun orElse e other = Stub.todo ()
+  fun map2 f ea eb = Stub.todo ()
+
+  (* Exercise 4.7: traverse / sequence を実装せよ． *)
+  fun traverse f xs = Stub.todo ()
+  fun sequence es = Stub.todo ()
+end

--- a/fp-in-sml/src/ch04_errorhandling/exercises/MyOption.sml
+++ b/fp-in-sml/src/ch04_errorhandling/exercises/MyOption.sml
@@ -1,0 +1,27 @@
+(* 第4章 演習 (MyOption)．toOption / fromOption は補助なので実装済み． *)
+structure MyOption: MY_OPTION =
+struct
+  datatype 'a t = None | Some of 'a
+
+  fun toOption None = NONE
+    | toOption (Some a) = SOME a
+
+  fun fromOption NONE = None
+    | fromOption (SOME a) = Some a
+
+  (* Exercise 4.1: 以下を実装せよ． *)
+  fun map f opt = Stub.todo ()
+  fun getOrElse opt default = Stub.todo ()
+  fun flatMap f opt = Stub.todo ()
+  fun orElse opt other = Stub.todo ()
+  fun filter p opt = Stub.todo ()
+
+  (* Exercise 4.3: 2つの Option を関数で合成せよ． *)
+  fun map2 f oa ob = Stub.todo ()
+
+  (* Exercise 4.4: Option のリストを「全部 Some なら Some リスト」にせよ． *)
+  fun sequence opts = Stub.todo ()
+
+  (* Exercise 4.5: traverse を実装せよ (sequence は traverse で書ける)． *)
+  fun traverse f xs = Stub.todo ()
+end

--- a/fp-in-sml/src/ch05_laziness/LAZY_LIST.sig
+++ b/fp-in-sml/src/ch05_laziness/LAZY_LIST.sig
@@ -1,0 +1,29 @@
+(* 第5章 遅延評価: 遅延リスト (本書の Stream)．
+ * SML は正格なので，尾 (tail) をサンク `unit -> 'a t` にして遅延を表現する．
+ * 頭 (head) は正格にしている (本書のようなメモ化はしない簡易版)． *)
+signature LAZY_LIST =
+sig
+  datatype 'a t = Nil | Cons of 'a * (unit -> 'a t)
+
+  (* Basis list との橋渡し (補助)．toList は全要素を評価する (無限列に使うな)． *)
+  val fromList: 'a list -> 'a t
+  val toList: 'a t -> 'a list
+
+  val headOption: 'a t -> 'a option
+  val take: int -> 'a t -> 'a t
+  val drop: int -> 'a t -> 'a t
+  val takeWhile: ('a -> bool) -> 'a t -> 'a t
+  val exists: ('a -> bool) -> 'a t -> bool
+  val forAll: ('a -> bool) -> 'a t -> bool
+
+  val map: ('a -> 'b) -> 'a t -> 'b t
+  val filter: ('a -> bool) -> 'a t -> 'a t
+  val append: 'a t -> (unit -> 'a t) -> 'a t (* 第2引数は遅延 *)
+  val flatMap: ('a -> 'b t) -> 'a t -> 'b t
+
+  (* 無限列 *)
+  val constant: 'a -> 'a t
+  val from: int -> int t
+  val fibs: unit -> int t
+  val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a t
+end

--- a/fp-in-sml/src/ch05_laziness/answers/LazyList.sml
+++ b/fp-in-sml/src/ch05_laziness/answers/LazyList.sml
@@ -1,0 +1,79 @@
+(* 第5章 解答例 (LazyList)． *)
+structure LazyList: LAZY_LIST =
+struct
+  datatype 'a t = Nil | Cons of 'a * (unit -> 'a t)
+
+  fun fromList [] = Nil
+    | fromList (x :: xs) =
+        Cons (x, fn () => fromList xs)
+
+  fun toList Nil = []
+    | toList (Cons (x, tl)) =
+        x :: toList (tl ())
+
+  fun headOption Nil = NONE
+    | headOption (Cons (x, _)) = SOME x
+
+  fun take n s =
+    if n <= 0 then
+      Nil
+    else
+      case s of
+        Nil => Nil
+      | Cons (x, tl) => Cons (x, fn () => take (n - 1) (tl ()))
+
+  fun drop n s =
+    if n <= 0 then
+      s
+    else
+      case s of
+        Nil => Nil
+      | Cons (_, tl) => drop (n - 1) (tl ())
+
+  fun takeWhile p Nil = Nil
+    | takeWhile p (Cons (x, tl)) =
+        if p x then Cons (x, fn () => takeWhile p (tl ())) else Nil
+
+  fun forAll p Nil = true
+    | forAll p (Cons (x, tl)) =
+        p x andalso forAll p (tl ())
+
+  fun exists p Nil = false
+    | exists p (Cons (x, tl)) =
+        p x orelse exists p (tl ())
+
+  fun map f Nil = Nil
+    | map f (Cons (x, tl)) =
+        Cons (f x, fn () => map f (tl ()))
+
+  fun filter p Nil = Nil
+    | filter p (Cons (x, tl)) =
+        if p x then Cons (x, fn () => filter p (tl ())) else filter p (tl ())
+
+  fun append Nil s2 = s2 ()
+    | append (Cons (x, tl)) s2 =
+        Cons (x, fn () => append (tl ()) s2)
+
+  fun flatMap f Nil = Nil
+    | flatMap f (Cons (x, tl)) =
+        append (f x) (fn () => flatMap f (tl ()))
+
+  fun constant a =
+    Cons (a, fn () => constant a)
+
+  fun from n =
+    Cons (n, fn () => from (n + 1))
+
+  fun fibs () =
+    let
+      fun go (a, b) =
+        Cons (a, fn () => go (b, a + b))
+    in
+      go (0, 1)
+    end
+
+  fun unfold z f =
+    case f z of
+      NONE => Nil
+    | SOME (a, z') => Cons (a, fn () => unfold z' f)
+end

--- a/fp-in-sml/src/ch05_laziness/exercises/LazyList.sml
+++ b/fp-in-sml/src/ch05_laziness/exercises/LazyList.sml
@@ -1,0 +1,39 @@
+(* 第5章 演習 (LazyList)．fromList / toList は補助なので実装済み． *)
+structure LazyList: LAZY_LIST =
+struct
+  datatype 'a t = Nil | Cons of 'a * (unit -> 'a t)
+
+  fun fromList [] = Nil
+    | fromList (x :: xs) =
+        Cons (x, fn () => fromList xs)
+
+  fun toList Nil = []
+    | toList (Cons (x, tl)) =
+        x :: toList (tl ())
+
+  (* Exercise 5.1: headOption を実装せよ． *)
+  fun headOption s = Stub.todo ()
+
+  (* Exercise 5.2: take / drop を実装せよ (take は遅延のまま返す)． *)
+  fun take n s = Stub.todo ()
+  fun drop n s = Stub.todo ()
+
+  (* Exercise 5.3: takeWhile を実装せよ． *)
+  fun takeWhile p s = Stub.todo ()
+
+  (* Exercise 5.4: forAll を実装せよ (偽が出たら早く止める)． *)
+  fun forAll p s = Stub.todo ()
+  fun exists p s = Stub.todo ()
+
+  (* Exercise 5.7: map / filter / append / flatMap を実装せよ (遅延を保つ)． *)
+  fun map f s = Stub.todo ()
+  fun filter p s = Stub.todo ()
+  fun append s1 s2 = Stub.todo ()
+  fun flatMap f s = Stub.todo ()
+
+  (* Exercise 5.8-5.11: 無限列． *)
+  fun constant a = Stub.todo ()
+  fun from n = Stub.todo ()
+  fun fibs () = Stub.todo ()
+  fun unfold z f = Stub.todo ()
+end

--- a/fp-in-sml/src/ch06_state/RNG.sig
+++ b/fp-in-sml/src/ch06_state/RNG.sig
@@ -1,0 +1,21 @@
+(* 第6章 純粋関数型の状態: 擬似乱数生成器 (RNG)．
+ * 乱数の「状態」を引き回し，'a rand = rng -> 'a * rng として合成していく．
+ * rng の中身 (線形合同法の 48bit 状態) は :> で隠す． *)
+signature RNG =
+sig
+  type rng
+  type 'a rand = rng -> 'a * rng
+
+  val simple: int -> rng
+
+  val nextInt: int rand (* 全 32bit 範囲 (負も出る) *)
+  val nonNegativeInt: int rand (* 0 以上 *)
+  val double: real rand (* [0.0, 1.0) *)
+
+  val unit: 'a -> 'a rand
+  val map: ('a -> 'b) -> 'a rand -> 'b rand
+  val map2: ('a * 'b -> 'c) -> 'a rand -> 'b rand -> 'c rand
+  val flatMap: ('a -> 'b rand) -> 'a rand -> 'b rand
+  val sequence: 'a rand list -> 'a list rand
+  val ints: int -> int list rand
+end

--- a/fp-in-sml/src/ch06_state/STATE.sig
+++ b/fp-in-sml/src/ch06_state/STATE.sig
@@ -1,0 +1,24 @@
+(* 第6章 一般化した状態モナド State．
+ * ('s, 'a) state は「状態 's を受け取り，結果 'a と次状態 's を返す」計算．
+ * 中身 (関数) は :> で隠し，run / state で出し入れする．
+ * 第6章では独自コンビネータとして実装し，第11章で MONAD シグネチャに接続する． *)
+signature STATE =
+sig
+  type ('s, 'a) state
+
+  val state: ('s -> 'a * 's) -> ('s, 'a) state (* 生成 *)
+  val run: ('s, 'a) state -> 's -> 'a * 's (* 実行 *)
+
+  val unit: 'a -> ('s, 'a) state
+  val map: ('a -> 'b) -> ('s, 'a) state -> ('s, 'b) state
+  val map2: ('a * 'b -> 'c)
+            -> ('s, 'a) state
+            -> ('s, 'b) state
+            -> ('s, 'c) state
+  val flatMap: ('a -> ('s, 'b) state) -> ('s, 'a) state -> ('s, 'b) state
+  val sequence: ('s, 'a) state list -> ('s, 'a list) state
+
+  val get: ('s, 's) state
+  val set: 's -> ('s, unit) state
+  val modify: ('s -> 's) -> ('s, unit) state
+end

--- a/fp-in-sml/src/ch06_state/answers/Rng.sml
+++ b/fp-in-sml/src/ch06_state/answers/Rng.sml
@@ -1,0 +1,47 @@
+(* 第6章 解答例 (Rng)． *)
+structure Rng :> RNG =
+struct
+  type rng = Word64.word
+  type 'a rand = rng -> 'a * rng
+
+  fun simple seed =
+    Word64.andb (Word64.fromInt seed, 0wxFFFFFFFFFFFF)
+
+  (* 線形合同法 (java.util.Random と同じ定数) で次の状態と値を得る． *)
+  fun nextInt r =
+    let
+      val r' = Word64.andb
+        (Word64.+ (Word64.* (r, 0wx5DEECE66D), 0wxB), 0wxFFFFFFFFFFFF)
+      val hi = Word32.fromLarge (Word64.toLarge (Word64.>> (r', 0w16)))
+    in
+      (Word32.toIntX hi, r')
+    end
+
+  (* 最小値は符号反転できないので ~(n + 1) で非負側へ折り返す． *)
+  fun nonNegativeInt r =
+    let val (n, r') = nextInt r
+    in (if n < 0 then ~(n + 1) else n, r')
+    end
+
+  fun double r =
+    let val (n, r') = nonNegativeInt r
+    in (Real.fromInt n / 2147483648.0, r')
+    end
+
+  fun unit a = fn r => (a, r)
+
+  fun map f ra =
+    fn r => let val (a, r') = ra r in (f a, r') end
+
+  fun flatMap g ra =
+    fn r => let val (a, r') = ra r in g a r' end
+
+  fun map2 f ra rb =
+    flatMap (fn a => map (fn b => f (a, b)) rb) ra
+
+  fun sequence rs =
+    List.foldr (fn (ra, acc) => map2 (op::) ra acc) (unit []) rs
+
+  fun ints n =
+    sequence (List.tabulate (n, fn _ => nonNegativeInt))
+end

--- a/fp-in-sml/src/ch06_state/answers/Rng.sml
+++ b/fp-in-sml/src/ch06_state/answers/Rng.sml
@@ -28,13 +28,17 @@ struct
     in (Real.fromInt n / 2147483648.0, r')
     end
 
-  fun unit a = fn r => (a, r)
+  fun unit a r = (a, r)
 
-  fun map f ra =
-    fn r => let val (a, r') = ra r in (f a, r') end
+  fun map f ra r =
+    let val (a, r') = ra r
+    in (f a, r')
+    end
 
-  fun flatMap g ra =
-    fn r => let val (a, r') = ra r in g a r' end
+  fun flatMap g ra r =
+    let val (a, r') = ra r
+    in g a r'
+    end
 
   fun map2 f ra rb =
     flatMap (fn a => map (fn b => f (a, b)) rb) ra

--- a/fp-in-sml/src/ch06_state/answers/State.sml
+++ b/fp-in-sml/src/ch06_state/answers/State.sml
@@ -1,0 +1,29 @@
+(* 第6章 解答例 (State)． *)
+structure State :> STATE =
+struct
+  (* 状態を受け取り (値と次の状態) を返す関数として表す． *)
+  type ('s, 'a) state = 's -> 'a * 's
+
+  (* state/run は封印した型の出入り口 (表現が関数そのものなので中身は恒等)． *)
+  fun state f = f
+  fun run st s = st s
+
+  fun unit a = fn s => (a, s)
+
+  fun map f st =
+    fn s => let val (a, s') = st s in (f a, s') end
+
+  fun flatMap g st =
+    fn s => let val (a, s') = st s in g a s' end
+
+  fun map2 f sa sb =
+    flatMap (fn a => map (fn b => f (a, b)) sb) sa
+
+  fun sequence sts =
+    List.foldr (fn (st, acc) => map2 (op::) st acc) (unit []) sts
+
+  val get = fn s => (s, s)
+  fun set s = fn _ => ((), s)
+  fun modify f =
+    fn s => ((), f s)
+end

--- a/fp-in-sml/src/ch06_state/answers/State.sml
+++ b/fp-in-sml/src/ch06_state/answers/State.sml
@@ -8,13 +8,17 @@ struct
   fun state f = f
   fun run st s = st s
 
-  fun unit a = fn s => (a, s)
+  fun unit a s = (a, s)
 
-  fun map f st =
-    fn s => let val (a, s') = st s in (f a, s') end
+  fun map f st s =
+    let val (a, s') = st s
+    in (f a, s')
+    end
 
-  fun flatMap g st =
-    fn s => let val (a, s') = st s in g a s' end
+  fun flatMap g st s =
+    let val (a, s') = st s
+    in g a s'
+    end
 
   fun map2 f sa sb =
     flatMap (fn a => map (fn b => f (a, b)) sb) sa
@@ -22,8 +26,7 @@ struct
   fun sequence sts =
     List.foldr (fn (st, acc) => map2 (op::) st acc) (unit []) sts
 
-  val get = fn s => (s, s)
-  fun set s = fn _ => ((), s)
-  fun modify f =
-    fn s => ((), f s)
+  fun get s = (s, s)
+  fun set s _ = ((), s)
+  fun modify f s = ((), f s)
 end

--- a/fp-in-sml/src/ch06_state/exercises/Rng.sml
+++ b/fp-in-sml/src/ch06_state/exercises/Rng.sml
@@ -1,0 +1,36 @@
+(* 第6章 演習 (Rng)．simple / nextInt (乱数エンジン) は提供済み． *)
+structure Rng :> RNG =
+struct
+  type rng = Word64.word
+  type 'a rand = rng -> 'a * rng
+
+  fun simple seed =
+    Word64.andb (Word64.fromInt seed, 0wxFFFFFFFFFFFF)
+
+  fun nextInt r =
+    let
+      val r' = Word64.andb
+        (Word64.+ (Word64.* (r, 0wx5DEECE66D), 0wxB), 0wxFFFFFFFFFFFF)
+      val hi = Word32.fromLarge (Word64.toLarge (Word64.>> (r', 0w16)))
+    in
+      (Word32.toIntX hi, r')
+    end
+
+  (* Exercise 6.1: 0 以上の整数を返せ (Int.minInt に注意)． *)
+  fun nonNegativeInt r = Stub.todo ()
+
+  (* Exercise 6.2: [0.0, 1.0) の実数を返せ． *)
+  fun double r = Stub.todo ()
+
+  (* Exercise 6.5-6.8: コンビネータを実装せよ． *)
+  fun unit a = Stub.todo ()
+  fun map f ra = Stub.todo ()
+  fun map2 f ra rb = Stub.todo ()
+  fun flatMap g ra = Stub.todo ()
+
+  (* Exercise 6.7: rand のリストをまとめる． *)
+  fun sequence rs = Stub.todo ()
+
+  (* n 個の nonNegativeInt をまとめる． *)
+  fun ints n = Stub.todo ()
+end

--- a/fp-in-sml/src/ch06_state/exercises/State.sml
+++ b/fp-in-sml/src/ch06_state/exercises/State.sml
@@ -1,0 +1,21 @@
+(* 第6章 演習 (State)．state / run は提供済み．
+ * get は値だが，多相のまま保つため無名関数 (値) として書いてある． *)
+structure State :> STATE =
+struct
+  type ('s, 'a) state = 's -> 'a * 's
+
+  fun state f = f
+  fun run st s = st s
+
+  (* Exercise 6.10: unit / map / map2 / flatMap / sequence を実装せよ． *)
+  fun unit a = fn s => Stub.todo ()
+  fun map f st = fn s => Stub.todo ()
+  fun map2 f sa sb = fn s => Stub.todo ()
+  fun flatMap g st = fn s => Stub.todo ()
+  fun sequence sts = fn s => Stub.todo ()
+
+  (* get / set / modify を実装せよ． *)
+  val get = fn s => Stub.todo ()
+  fun set s = fn s' => Stub.todo ()
+  fun modify f = fn s => Stub.todo ()
+end

--- a/fp-in-sml/src/ch06_state/exercises/State.sml
+++ b/fp-in-sml/src/ch06_state/exercises/State.sml
@@ -1,5 +1,4 @@
-(* 第6章 演習 (State)．state / run は提供済み．
- * get は値だが，多相のまま保つため無名関数 (値) として書いてある． *)
+(* 第6章 演習 (State)．state / run は提供済み． *)
 structure State :> STATE =
 struct
   type ('s, 'a) state = 's -> 'a * 's
@@ -8,14 +7,14 @@ struct
   fun run st s = st s
 
   (* Exercise 6.10: unit / map / map2 / flatMap / sequence を実装せよ． *)
-  fun unit a = fn s => Stub.todo ()
-  fun map f st = fn s => Stub.todo ()
-  fun map2 f sa sb = fn s => Stub.todo ()
-  fun flatMap g st = fn s => Stub.todo ()
-  fun sequence sts = fn s => Stub.todo ()
+  fun unit a s = Stub.todo ()
+  fun map f st s = Stub.todo ()
+  fun map2 f sa sb s = Stub.todo ()
+  fun flatMap g st s = Stub.todo ()
+  fun sequence sts s = Stub.todo ()
 
   (* get / set / modify を実装せよ． *)
-  val get = fn s => Stub.todo ()
-  fun set s = fn s' => Stub.todo ()
-  fun modify f = fn s => Stub.todo ()
+  fun get s = Stub.todo ()
+  fun set s s' = Stub.todo ()
+  fun modify f s = Stub.todo ()
 end

--- a/fp-in-sml/src/ch08_testing/GEN.sig
+++ b/fp-in-sml/src/ch08_testing/GEN.sig
@@ -1,0 +1,23 @@
+(* 第8章 プロパティベーステストの自作: ジェネレータ Gen．
+ * 第6章の Rng の上に組み立てる ('a gen は 'a Rng.rand そのもの)．
+ * (この Gen は lib/Pbt とは別物で，こちらが「自作版」．) *)
+signature GEN =
+sig
+  type 'a gen = 'a Rng.rand
+
+  val sample: 'a gen -> Rng.rng -> 'a * Rng.rng
+
+  val unit: 'a -> 'a gen
+  val boolean: bool gen
+  (* [start, stopExclusive) の整数 *)
+  val choose: int * int -> int gen
+
+  val map: ('a -> 'b) -> 'a gen -> 'b gen
+  val map2: ('a * 'b -> 'c) -> 'a gen -> 'b gen -> 'c gen
+  val flatMap: ('a -> 'b gen) -> 'a gen -> 'b gen
+
+  val listOfN: int -> 'a gen -> 'a list gen
+  val listOf: 'a gen -> 'a list gen
+  val pair: 'a gen -> 'b gen -> ('a * 'b) gen
+  val union: 'a gen -> 'a gen -> 'a gen
+end

--- a/fp-in-sml/src/ch08_testing/PROP.sig
+++ b/fp-in-sml/src/ch08_testing/PROP.sig
@@ -1,0 +1,13 @@
+(* 第8章 性質 (Prop)．Gen で乱入力を作り，述語を多数回試す．
+ * 失敗したら反例 (show 済み文字列) を持つ Falsified を返す． *)
+signature PROP =
+sig
+  datatype result = Passed | Falsified of string
+
+  type prop = int -> Rng.rng -> result (* テスト回数 -> 乱数 -> 結果 *)
+
+  val forAll: 'a Gen.gen -> ('a -> string) -> ('a -> bool) -> prop
+  val andProp: prop * prop -> prop
+  val run: prop -> int -> Rng.rng -> result
+  val isPassed: result -> bool
+end

--- a/fp-in-sml/src/ch08_testing/answers/Gen.sml
+++ b/fp-in-sml/src/ch08_testing/answers/Gen.sml
@@ -1,0 +1,30 @@
+(* 第8章 解答例 (Gen)．Rng のコンビネータを土台にする． *)
+structure Gen: GEN =
+struct
+  type 'a gen = 'a Rng.rand
+
+  fun sample g rng = g rng
+
+  val unit = Rng.unit
+
+  val boolean = Rng.map (fn n => n mod 2 = 0) Rng.nonNegativeInt
+
+  fun choose (start, stopExclusive) =
+    Rng.map (fn n => start + n mod (stopExclusive - start)) Rng.nonNegativeInt
+
+  val map = Rng.map
+  val map2 = Rng.map2
+  val flatMap = Rng.flatMap
+
+  fun listOfN n g =
+    Rng.sequence (List.tabulate (n, fn _ => g))
+
+  fun listOf g =
+    flatMap (fn n => listOfN n g) (choose (0, 16))
+
+  fun pair ga gb =
+    map2 (fn x => x) ga gb
+
+  fun union ga gb =
+    flatMap (fn b => if b then ga else gb) boolean
+end

--- a/fp-in-sml/src/ch08_testing/answers/Prop.sml
+++ b/fp-in-sml/src/ch08_testing/answers/Prop.sml
@@ -1,0 +1,32 @@
+(* 第8章 解答例 (Prop)． *)
+structure Prop: PROP =
+struct
+  datatype result = Passed | Falsified of string
+
+  type prop = int -> Rng.rng -> result
+
+  fun forAll g show pred =
+    fn n =>
+      fn rng =>
+        let
+          fun loop (0, _) = Passed
+            | loop (k, r) =
+                let val (a, r') = Gen.sample g r
+                in if pred a then loop (k - 1, r') else Falsified (show a)
+                end
+        in
+          loop (n, rng)
+        end
+
+  fun andProp (p1, p2) =
+    fn n =>
+      fn rng =>
+        (case p1 n rng of
+           Passed => p2 n rng
+         | falsified => falsified)
+
+  fun run p n rng = p n rng
+
+  fun isPassed Passed = true
+    | isPassed (Falsified _) = false
+end

--- a/fp-in-sml/src/ch08_testing/exercises/Gen.sml
+++ b/fp-in-sml/src/ch08_testing/exercises/Gen.sml
@@ -7,7 +7,7 @@ struct
 
   (* Exercise 8.4-8.13: 以下を実装せよ．Rng のコンビネータを使ってよい． *)
   fun unit a = Stub.todo ()
-  val boolean = fn r => Stub.todo ()
+  fun boolean r = Stub.todo ()
   fun choose (start, stopExclusive) = Stub.todo ()
 
   fun map f g = Stub.todo ()

--- a/fp-in-sml/src/ch08_testing/exercises/Gen.sml
+++ b/fp-in-sml/src/ch08_testing/exercises/Gen.sml
@@ -1,0 +1,21 @@
+(* 第8章 演習 (Gen)．sample は補助として提供済み． *)
+structure Gen: GEN =
+struct
+  type 'a gen = 'a Rng.rand
+
+  fun sample g rng = g rng
+
+  (* Exercise 8.4-8.13: 以下を実装せよ．Rng のコンビネータを使ってよい． *)
+  fun unit a = Stub.todo ()
+  val boolean = fn r => Stub.todo ()
+  fun choose (start, stopExclusive) = Stub.todo ()
+
+  fun map f g = Stub.todo ()
+  fun map2 f ga gb = Stub.todo ()
+  fun flatMap f g = Stub.todo ()
+
+  fun listOfN n g = Stub.todo ()
+  fun listOf g = Stub.todo ()
+  fun pair ga gb = Stub.todo ()
+  fun union ga gb = Stub.todo ()
+end

--- a/fp-in-sml/src/ch08_testing/exercises/Prop.sml
+++ b/fp-in-sml/src/ch08_testing/exercises/Prop.sml
@@ -1,0 +1,17 @@
+(* 第8章 演習 (Prop)．run / isPassed は補助として提供済み． *)
+structure Prop: PROP =
+struct
+  datatype result = Passed | Falsified of string
+
+  type prop = int -> Rng.rng -> result
+
+  (* Exercise 8.9: forAll / andProp を実装せよ．
+   * forAll: n 回 gen から取り出し，述語が偽になったら Falsified (show 反例)． *)
+  fun forAll g show pred = Stub.todo ()
+  fun andProp (p1, p2) = Stub.todo ()
+
+  fun run p n rng = p n rng
+
+  fun isPassed Passed = true
+    | isPassed (Falsified _) = false
+end

--- a/fp-in-sml/src/ch09_parsing/JSON.sig
+++ b/fp-in-sml/src/ch09_parsing/JSON.sig
@@ -1,0 +1,14 @@
+(* 第9章 応用: JSON パーサ．Parser の公開 API だけで組み立てる
+ * (Parser の中身には触れない)．エスケープや厳密な数値仕様は簡略化している． *)
+signature JSON =
+sig
+  datatype json =
+    JNull
+  | JBool of bool
+  | JNumber of real
+  | JString of string
+  | JArray of json list
+  | JObject of (string * json) list
+
+  val parse: string -> json Parser.result
+end

--- a/fp-in-sml/src/ch09_parsing/Json.sml
+++ b/fp-in-sml/src/ch09_parsing/Json.sml
@@ -1,0 +1,69 @@
+(* 第9章 JSON パーサ (演習・解答で共通)．
+ * Parser の演習を実装すると，このパーサがそのまま動くようになる． *)
+structure Json: JSON =
+struct
+  structure P = Parser
+
+  datatype json =
+    JNull
+  | JBool of bool
+  | JNumber of real
+  | JString of string
+  | JArray of json list
+  | JObject of (string * json) list
+
+  val ws = P.many (P.satisfy Char.isSpace)
+  fun lexeme p =
+    P.map2 (fn (a, _) => a) p ws
+  fun symbol c =
+    lexeme (P.char c)
+  fun keyword kw =
+    lexeme (P.string kw)
+
+  (* open_ p close_ → p の結果だけ取り出す *)
+  fun between open_ close_ p =
+    P.map2 (fn (x, _) => x) (P.map2 (fn (_, x) => x) open_ p) close_
+
+  fun choice ps =
+    List.foldr P.or (P.fail "JSON 値ではない") ps
+
+  val numberP =
+    lexeme
+      (P.flatMap
+         (fn chars =>
+            case Real.fromString (String.implode chars) of
+              SOME r => P.succeed (JNumber r)
+            | NONE => P.fail "数値として解釈できない")
+         (P.many1 (P.satisfy (fn c =>
+            Char.isDigit c orelse Char.contains "+-.eE" c))))
+
+  (* エスケープ無しの単純な文字列リテラル *)
+  val stringRaw =
+    between (P.char #"\"") (P.char #"\"")
+      (P.map String.implode (P.many (P.satisfy (fn c => c <> #"\""))))
+
+  val jstring = lexeme (P.map JString stringRaw)
+  val jnull = P.map (fn _ => JNull) (keyword "null")
+  val jbool = P.or
+    ( P.map (fn _ => JBool true) (keyword "true")
+    , P.map (fn _ => JBool false) (keyword "false")
+    )
+
+  fun valueP () =
+    choice [jnull, jbool, numberP, jstring, arrayP (), objectP ()]
+
+  and arrayP () =
+    P.map JArray (between (symbol #"[") (symbol #"]")
+      (P.sepBy (P.lazy valueP) (symbol #",")))
+
+  and pairP () =
+    P.map2 (fn (k, v) => (k, v)) (lexeme stringRaw)
+      (P.map2 (fn (_, v) => v) (symbol #":") (P.lazy valueP))
+
+  and objectP () =
+    P.map JObject (between (symbol #"{") (symbol #"}")
+      (P.sepBy (pairP ()) (symbol #",")))
+
+  fun parse s =
+    P.run (P.map2 (fn (_, v) => v) ws (valueP ())) s
+end

--- a/fp-in-sml/src/ch09_parsing/PARSER.sig
+++ b/fp-in-sml/src/ch09_parsing/PARSER.sig
@@ -1,0 +1,31 @@
+(* 第9章 パーサコンビネータ．
+ * 'a parser の中身 (入力文字列と位置を受け取り結果か失敗を返す関数) は :> で隠す．
+ * 小さな部品 (succeed / char / satisfy ...) を or / many / map2 などで組み上げる．
+ * 再帰的な文法 (JSON の値→配列→値…) のために lazy を用意する． *)
+signature PARSER =
+sig
+  type 'a parser
+  datatype 'a result = Success of 'a | Failure of string
+
+  val run: 'a parser -> string -> 'a result
+
+  val succeed: 'a -> 'a parser
+  val fail: string -> 'a parser
+  val satisfy: (char -> bool) -> char parser
+  val char: char -> char parser
+  val string: string -> string parser
+
+  val map: ('a -> 'b) -> 'a parser -> 'b parser
+  val flatMap: ('a -> 'b parser) -> 'a parser -> 'b parser
+  val map2: ('a * 'b -> 'c) -> 'a parser -> 'b parser -> 'c parser
+  val product: 'a parser * 'b parser -> ('a * 'b) parser
+  val or: 'a parser * 'a parser -> 'a parser
+
+  val many: 'a parser -> 'a list parser
+  val many1: 'a parser -> 'a list parser
+  val listOfN: int -> 'a parser -> 'a list parser
+  val sepBy: 'a parser -> 'b parser -> 'a list parser
+
+  (* 再帰文法を組むためのサンク．lazy (fn () => p) で p の評価を実行時まで遅らせる． *)
+  val lazy: (unit -> 'a parser) -> 'a parser
+end

--- a/fp-in-sml/src/ch09_parsing/answers/Parser.sml
+++ b/fp-in-sml/src/ch09_parsing/answers/Parser.sml
@@ -10,48 +10,38 @@ struct
       Ok (a, _) => Success a
     | Err msg => Failure msg
 
-  fun succeed a =
-    fn s => fn i => Ok (a, i)
+  fun succeed a s i = Ok (a, i)
 
-  fun fail msg =
-    fn s => fn i => Err msg
+  fun fail msg s i = Err msg
 
-  fun satisfy pred =
-    fn s =>
-      fn i =>
-        if i < size s andalso pred (String.sub (s, i)) then
-          Ok (String.sub (s, i), i + 1)
-        else
-          Err ("位置 " ^ Int.toString i ^ ": 想定外の文字")
+  fun satisfy pred s i =
+    if i < size s andalso pred (String.sub (s, i)) then
+      Ok (String.sub (s, i), i + 1)
+    else
+      Err ("位置 " ^ Int.toString i ^ ": 想定外の文字")
 
   fun char c =
     satisfy (fn x => x = c)
 
-  fun string lit =
-    fn s =>
-      fn i =>
-        let
-          val n = size lit
-        in
-          if i + n <= size s andalso String.substring (s, i, n) = lit then
-            Ok (lit, i + n)
-          else
-            Err ("位置 " ^ Int.toString i ^ ": \"" ^ lit ^ "\" を期待")
-        end
+  fun string lit s i =
+    let
+      val n = size lit
+    in
+      if i + n <= size s andalso String.substring (s, i, n) = lit then
+        Ok (lit, i + n)
+      else
+        Err ("位置 " ^ Int.toString i ^ ": \"" ^ lit ^ "\" を期待")
+    end
 
-  fun map f p =
-    fn s =>
-      fn i =>
-        (case p s i of
-           Ok (a, i') => Ok (f a, i')
-         | Err m => Err m)
+  fun map f p s i =
+    case p s i of
+      Ok (a, i') => Ok (f a, i')
+    | Err m => Err m
 
-  fun flatMap f p =
-    fn s =>
-      fn i =>
-        (case p s i of
-           Ok (a, i') => f a s i'
-         | Err m => Err m)
+  fun flatMap f p s i =
+    case p s i of
+      Ok (a, i') => f a s i'
+    | Err m => Err m
 
   fun map2 f pa pb =
     flatMap (fn a => map (fn b => f (a, b)) pb) pa
@@ -59,27 +49,23 @@ struct
   fun product (pa, pb) =
     map2 (fn x => x) pa pb
 
-  fun or (p1, p2) =
-    fn s =>
-      fn i =>
-        (case p1 s i of
-           Ok r => Ok r
-         | Err _ => p2 s i)
+  fun or (p1, p2) s i =
+    case p1 s i of
+      Ok r => Ok r
+    | Err _ => p2 s i
 
-  fun many p =
-    fn s =>
-      fn i =>
-        let
-          fun loop (acc, j) =
-            case p s j of
-              Ok (a, j') =>
-                if j' = j then (List.rev acc, j) (* 無限ループ防止 *)
-                else loop (a :: acc, j')
-            | Err _ => (List.rev acc, j)
-          val (xs, j) = loop ([], i)
-        in
-          Ok (xs, j)
-        end
+  fun many p s i =
+    let
+      fun loop (acc, j) =
+        case p s j of
+          Ok (a, j') =>
+            if j' = j then (List.rev acc, j) (* 無限ループ防止 *)
+            else loop (a :: acc, j')
+        | Err _ => (List.rev acc, j)
+      val (xs, j) = loop ([], i)
+    in
+      Ok (xs, j)
+    end
 
   fun many1 p =
     map2 (fn (x, xs) => x :: xs) p (many p)
@@ -96,6 +82,6 @@ struct
       or (nonEmpty, succeed [])
     end
 
-  fun lazy thunk =
-    fn s => fn i => thunk () s i
+  fun lazy thunk s i =
+    thunk () s i
 end

--- a/fp-in-sml/src/ch09_parsing/answers/Parser.sml
+++ b/fp-in-sml/src/ch09_parsing/answers/Parser.sml
@@ -1,0 +1,101 @@
+(* 第9章 解答例 (Parser)．入力は文字列 + 位置で持ち回す． *)
+structure Parser :> PARSER =
+struct
+  datatype 'a presult = Ok of 'a * int | Err of string
+  type 'a parser = string -> int -> 'a presult
+  datatype 'a result = Success of 'a | Failure of string
+
+  fun run p s =
+    case p s 0 of
+      Ok (a, _) => Success a
+    | Err msg => Failure msg
+
+  fun succeed a =
+    fn s => fn i => Ok (a, i)
+
+  fun fail msg =
+    fn s => fn i => Err msg
+
+  fun satisfy pred =
+    fn s =>
+      fn i =>
+        if i < size s andalso pred (String.sub (s, i)) then
+          Ok (String.sub (s, i), i + 1)
+        else
+          Err ("位置 " ^ Int.toString i ^ ": 想定外の文字")
+
+  fun char c =
+    satisfy (fn x => x = c)
+
+  fun string lit =
+    fn s =>
+      fn i =>
+        let
+          val n = size lit
+        in
+          if i + n <= size s andalso String.substring (s, i, n) = lit then
+            Ok (lit, i + n)
+          else
+            Err ("位置 " ^ Int.toString i ^ ": \"" ^ lit ^ "\" を期待")
+        end
+
+  fun map f p =
+    fn s =>
+      fn i =>
+        (case p s i of
+           Ok (a, i') => Ok (f a, i')
+         | Err m => Err m)
+
+  fun flatMap f p =
+    fn s =>
+      fn i =>
+        (case p s i of
+           Ok (a, i') => f a s i'
+         | Err m => Err m)
+
+  fun map2 f pa pb =
+    flatMap (fn a => map (fn b => f (a, b)) pb) pa
+
+  fun product (pa, pb) =
+    map2 (fn x => x) pa pb
+
+  fun or (p1, p2) =
+    fn s =>
+      fn i =>
+        (case p1 s i of
+           Ok r => Ok r
+         | Err _ => p2 s i)
+
+  fun many p =
+    fn s =>
+      fn i =>
+        let
+          fun loop (acc, j) =
+            case p s j of
+              Ok (a, j') =>
+                if j' = j then (List.rev acc, j) (* 無限ループ防止 *)
+                else loop (a :: acc, j')
+            | Err _ => (List.rev acc, j)
+          val (xs, j) = loop ([], i)
+        in
+          Ok (xs, j)
+        end
+
+  fun many1 p =
+    map2 (fn (x, xs) => x :: xs) p (many p)
+
+  fun listOfN n p =
+    if n <= 0 then succeed []
+    else map2 (fn (x, xs) => x :: xs) p (listOfN (n - 1) p)
+
+  fun sepBy p sep =
+    let
+      val rest = many (flatMap (fn _ => p) sep)
+      val nonEmpty = map2 (fn (x, xs) => x :: xs) p rest
+    in
+      or (nonEmpty, succeed [])
+    end
+
+  fun lazy thunk =
+    fn s => fn i => thunk () s i
+end

--- a/fp-in-sml/src/ch09_parsing/exercises/Parser.sml
+++ b/fp-in-sml/src/ch09_parsing/exercises/Parser.sml
@@ -1,0 +1,46 @@
+(* 第9章 演習 (Parser)．
+ * 各コンビネータは「パーサ (= fn s => fn i => ...) を返す」形にしてあるので，
+ * 本体 Stub.todo () が走るのは実行時 (run された時)．組み立て時には走らない． *)
+structure Parser :> PARSER =
+struct
+  datatype 'a presult = Ok of 'a * int | Err of string
+  type 'a parser = string -> int -> 'a presult
+  datatype 'a result = Success of 'a | Failure of string
+
+  fun run p s = Stub.todo ()
+
+  (* Exercise 9.x: 以下を実装せよ． *)
+  fun succeed a =
+    fn s => fn i => Stub.todo ()
+  fun fail msg =
+    fn s => fn i => Stub.todo ()
+  fun satisfy pred =
+    fn s => fn i => Stub.todo ()
+  fun char c =
+    fn s => fn i => Stub.todo ()
+  fun string lit =
+    fn s => fn i => Stub.todo ()
+
+  fun map f p =
+    fn s => fn i => Stub.todo ()
+  fun flatMap f p =
+    fn s => fn i => Stub.todo ()
+  fun map2 f pa pb =
+    fn s => fn i => Stub.todo ()
+  fun product (pa, pb) =
+    fn s => fn i => Stub.todo ()
+  fun or (p1, p2) =
+    fn s => fn i => Stub.todo ()
+
+  fun many p =
+    fn s => fn i => Stub.todo ()
+  fun many1 p =
+    fn s => fn i => Stub.todo ()
+  fun listOfN n p =
+    fn s => fn i => Stub.todo ()
+  fun sepBy p sep =
+    fn s => fn i => Stub.todo ()
+
+  fun lazy thunk =
+    fn s => fn i => Stub.todo ()
+end

--- a/fp-in-sml/src/ch09_parsing/exercises/Parser.sml
+++ b/fp-in-sml/src/ch09_parsing/exercises/Parser.sml
@@ -1,46 +1,44 @@
-(* 第9章 演習 (Parser)．
- * 各コンビネータは「パーサ (= fn s => fn i => ...) を返す」形にしてあるので，
- * 本体 Stub.todo () が走るのは実行時 (run された時)．組み立て時には走らない． *)
+(* 第9章 演習 (Parser)． *)
 structure Parser :> PARSER =
 struct
   datatype 'a presult = Ok of 'a * int | Err of string
   type 'a parser = string -> int -> 'a presult
   datatype 'a result = Success of 'a | Failure of string
 
+  (* p を入力文字列 s に位置 0 から適用し，Ok なら Success，Err なら Failure に変換する． *)
   fun run p s = Stub.todo ()
 
-  (* Exercise 9.x: 以下を実装せよ． *)
-  fun succeed a =
-    fn s => fn i => Stub.todo ()
-  fun fail msg =
-    fn s => fn i => Stub.todo ()
-  fun satisfy pred =
-    fn s => fn i => Stub.todo ()
-  fun char c =
-    fn s => fn i => Stub.todo ()
-  fun string lit =
-    fn s => fn i => Stub.todo ()
+  (* 入力を消費せず，常に a を返して成功する． *)
+  fun succeed a s i = Stub.todo ()
+  (* 常に msg で失敗する． *)
+  fun fail msg s i = Stub.todo ()
+  (* 現在位置の1文字が pred を満たせば消費して返す．満たさない／末尾なら失敗． *)
+  fun satisfy pred s i = Stub.todo ()
+  (* 文字 c にちょうど一致する (satisfy で書ける)． *)
+  fun char c s i = Stub.todo ()
+  (* 文字列 lit にちょうど一致する． *)
+  fun string lit s i = Stub.todo ()
 
-  fun map f p =
-    fn s => fn i => Stub.todo ()
-  fun flatMap f p =
-    fn s => fn i => Stub.todo ()
-  fun map2 f pa pb =
-    fn s => fn i => Stub.todo ()
-  fun product (pa, pb) =
-    fn s => fn i => Stub.todo ()
-  fun or (p1, p2) =
-    fn s => fn i => Stub.todo ()
+  (* p の成功結果に f を適用する． *)
+  fun map f p s i = Stub.todo ()
+  (* p を実行し，その結果 a から次のパーサ f a を選んで続ける (逐次)． *)
+  fun flatMap f p s i = Stub.todo ()
+  (* pa, pb を順に実行し，両方成功なら f (a, b)． *)
+  fun map2 f pa pb s i = Stub.todo ()
+  (* pa, pb を順に実行し，結果をタプルにする． *)
+  fun product (pa, pb) s i = Stub.todo ()
+  (* まず p1 を試し，失敗したら p2 を試す． *)
+  fun or (p1, p2) s i = Stub.todo ()
 
-  fun many p =
-    fn s => fn i => Stub.todo ()
-  fun many1 p =
-    fn s => fn i => Stub.todo ()
-  fun listOfN n p =
-    fn s => fn i => Stub.todo ()
-  fun sepBy p sep =
-    fn s => fn i => Stub.todo ()
+  (* p を 0 回以上できるだけ繰り返し，結果のリストを返す． *)
+  fun many p s i = Stub.todo ()
+  (* p を 1 回以上繰り返す (0 回なら失敗)． *)
+  fun many1 p s i = Stub.todo ()
+  (* p をちょうど n 回繰り返す． *)
+  fun listOfN n p s i = Stub.todo ()
+  (* sep 区切りで p を 0 個以上並べたものを読む (区切りの結果は捨てる)． *)
+  fun sepBy p sep s i = Stub.todo ()
 
-  fun lazy thunk =
-    fn s => fn i => Stub.todo ()
+  (* thunk () を実行時まで遅延して適用する (再帰文法用)． *)
+  fun lazy thunk s i = Stub.todo ()
 end

--- a/fp-in-sml/src/ch10_monoids/MONOID.sig
+++ b/fp-in-sml/src/ch10_monoids/MONOID.sig
@@ -1,0 +1,8 @@
+(* 第10章 モノイド: 結合的な二項演算 combine と単位元 empty を持つ型．
+ * 法則: combine が結合的で，empty が左右の単位元． *)
+signature MONOID =
+sig
+  type m
+  val empty: m
+  val combine: m * m -> m
+end

--- a/fp-in-sml/src/ch10_monoids/answers/Monoids.sml
+++ b/fp-in-sml/src/ch10_monoids/answers/Monoids.sml
@@ -1,0 +1,45 @@
+(* 第10章 解答例 (モノイド)． *)
+
+structure IntAdd: MONOID =
+struct
+  type m = int
+  val empty = 0
+  fun combine (a, b) = a + b
+end
+
+structure IntMul: MONOID =
+struct
+  type m = int
+  val empty = 1
+  fun combine (a, b) = a * b
+end
+
+structure StringM: MONOID =
+struct
+  type m = string
+  val empty = ""
+  fun combine (a, b) = a ^ b
+end
+
+structure BoolOr: MONOID =
+struct
+  type m = bool
+  val empty = false
+  fun combine (a, b) = a orelse b
+end
+
+structure BoolAnd: MONOID =
+struct
+  type m = bool
+  val empty = true
+  fun combine (a, b) = a andalso b
+end
+
+functor MonoidOps(M: MONOID) =
+struct
+  (* foldr で左から右の順序を保つ (combine (a, b) = a ⊕ b のため)． *)
+  fun concatenate xs =
+    List.foldr M.combine M.empty xs
+  fun foldMap f xs =
+    concatenate (List.map f xs)
+end

--- a/fp-in-sml/src/ch10_monoids/exercises/Monoids.sml
+++ b/fp-in-sml/src/ch10_monoids/exercises/Monoids.sml
@@ -1,9 +1,5 @@
 (* 第10章 演習 (モノイドのインスタンスと派生関数)．
- * 各インスタンスは MONOID を透過注釈 `:` で実装し，具体型 (int/string/bool) を公開する．
- *
- * 注意: empty は「値」なので Stub.todo () にすると読込時に即評価されて落ちる．
- * そのため無害なプレースホルダを置いてある．各 empty を正しい単位元に直すこと
- * (combine が未実装のうちはテストは todo 表示のまま)． *)
+ * 各 empty を正しい単位元に直すこと (combine が未実装のうちはテストは todo 表示のまま)． *)
 
 structure IntAdd: MONOID =
 struct

--- a/fp-in-sml/src/ch10_monoids/exercises/Monoids.sml
+++ b/fp-in-sml/src/ch10_monoids/exercises/Monoids.sml
@@ -1,0 +1,48 @@
+(* 第10章 演習 (モノイドのインスタンスと派生関数)．
+ * 各インスタンスは MONOID を透過注釈 `:` で実装し，具体型 (int/string/bool) を公開する．
+ *
+ * 注意: empty は「値」なので Stub.todo () にすると読込時に即評価されて落ちる．
+ * そのため無害なプレースホルダを置いてある．各 empty を正しい単位元に直すこと
+ * (combine が未実装のうちはテストは todo 表示のまま)． *)
+
+structure IntAdd: MONOID =
+struct
+  type m = int
+  val empty: int = 0 (* TODO: 正しい単位元に *)
+  fun combine (a, b) = Stub.todo ()
+end
+
+structure IntMul: MONOID =
+struct
+  type m = int
+  val empty: int = 0 (* TODO: 正しい単位元に *)
+  fun combine (a, b) = Stub.todo ()
+end
+
+structure StringM: MONOID =
+struct
+  type m = string
+  val empty: string = "" (* TODO: 正しい単位元に *)
+  fun combine (a, b) = Stub.todo ()
+end
+
+structure BoolOr: MONOID =
+struct
+  type m = bool
+  val empty: bool = false (* TODO: 正しい単位元に *)
+  fun combine (a, b) = Stub.todo ()
+end
+
+structure BoolAnd: MONOID =
+struct
+  type m = bool
+  val empty: bool = false (* TODO: 正しい単位元に *)
+  fun combine (a, b) = Stub.todo ()
+end
+
+(* Exercise 10.x: モノイドを使った汎用関数．M をどのインスタンスにも適用できる． *)
+functor MonoidOps(M: MONOID) =
+struct
+  fun concatenate xs = Stub.todo ()
+  fun foldMap f xs = Stub.todo ()
+end

--- a/fp-in-sml/src/ch11_monads/MONAD.sig
+++ b/fp-in-sml/src/ch11_monads/MONAD.sig
@@ -1,0 +1,10 @@
+(* 第11章 モナド: unit と flatMap を持つ型構築子．
+ * SML には高階型 (HKT) が無いので，'a t を持つ「モジュール」を MONAD で表し，
+ * 派生関数 (map / map2 / sequence ...) は functor MonadUtil で生成する．
+ * 注意: ここでの functor は ML のモジュール関数であり，Scala の Functor とは別物． *)
+signature MONAD =
+sig
+  type 'a t
+  val unit: 'a -> 'a t
+  val flatMap: ('a -> 'b t) -> 'a t -> 'b t
+end

--- a/fp-in-sml/src/ch11_monads/MonadInstances.sml
+++ b/fp-in-sml/src/ch11_monads/MonadInstances.sml
@@ -1,0 +1,27 @@
+(* 第11章 モナドのインスタンス (演習・解答で共通)．
+ * unit / flatMap を与えるだけの薄い配線．派生関数は MonadUtil が作る．
+ * State は型引数が2つ (s, a) あるので，s を functor で固定して 'a t にする． *)
+
+structure OptionMonad: MONAD =
+struct
+  type 'a t = 'a option
+  fun unit a = SOME a
+  fun flatMap _ NONE = NONE
+    | flatMap f (SOME a) = f a
+end
+
+structure ListMonad: MONAD =
+struct
+  type 'a t = 'a list
+  fun unit a = [a]
+  fun flatMap f xs =
+    List.concat (List.map f xs)
+end
+
+(* 状態型 s を固定して State をモナドにする． *)
+functor StateMonadFn (type s): MONAD =
+struct
+  type 'a t = (s, 'a) State.state
+  val unit = State.unit
+  val flatMap = State.flatMap
+end

--- a/fp-in-sml/src/ch11_monads/answers/MonadUtil.sml
+++ b/fp-in-sml/src/ch11_monads/answers/MonadUtil.sml
@@ -1,0 +1,28 @@
+(* 第11章 解答例 (MonadUtil)．
+ * HKT や型クラスが無いので，unit と flatMap だけを持つ MONAD を受け取り，
+ * 派生関数 (map/map2/sequence/...) をファンクタで一括生成する． *)
+functor MonadUtil(M: MONAD) =
+struct
+  open M
+
+  fun map f m =
+    flatMap (fn a => unit (f a)) m
+
+  fun map2 f ma mb =
+    flatMap (fn a => map (fn b => f (a, b)) mb) ma
+
+  fun product (ma, mb) =
+    map2 (fn x => x) ma mb
+
+  fun sequence ms =
+    List.foldr (fn (m, acc) => map2 (fn (x, xs) => x :: xs) m acc) (unit []) ms
+
+  fun traverse f xs =
+    sequence (List.map f xs)
+
+  fun replicateM n m =
+    sequence (List.tabulate (n, fn _ => m))
+
+  fun join mma =
+    flatMap (fn m => m) mma
+end

--- a/fp-in-sml/src/ch11_monads/exercises/MonadUtil.sml
+++ b/fp-in-sml/src/ch11_monads/exercises/MonadUtil.sml
@@ -1,0 +1,16 @@
+(* 第11章 演習 (MonadUtil)．
+ * unit と flatMap だけから，汎用の派生関数を導く functor．
+ * どのモナド M に適用しても map / sequence などが手に入る． *)
+functor MonadUtil(M: MONAD) =
+struct
+  open M
+
+  (* Exercise 11.x: unit / flatMap だけを使って以下を実装せよ． *)
+  fun map f m = Stub.todo ()
+  fun map2 f ma mb = Stub.todo ()
+  fun product (ma, mb) = Stub.todo ()
+  fun sequence ms = Stub.todo ()
+  fun traverse f xs = Stub.todo ()
+  fun replicateM n m = Stub.todo ()
+  fun join mma = Stub.todo ()
+end

--- a/fp-in-sml/src/ch12_applicative/APPLICATIVE.sig
+++ b/fp-in-sml/src/ch12_applicative/APPLICATIVE.sig
@@ -1,0 +1,10 @@
+(* 第12章 アプリカティブ (Applicative)．
+ * 原始操作は unit と map2．flatMap が無いぶんモナドより弱いが，その代わり
+ * 「独立した複数の計算をまとめる」用途に向き，誤りの蓄積などができる．
+ * 派生関数 (map / ap / sequence / traverse ...) は functor ApplicativeUtil で生成． *)
+signature APPLICATIVE =
+sig
+  type 'a t
+  val unit: 'a -> 'a t
+  val map2: ('a * 'b -> 'c) -> 'a t -> 'b t -> 'c t
+end

--- a/fp-in-sml/src/ch12_applicative/ApplicativeInstances.sml
+++ b/fp-in-sml/src/ch12_applicative/ApplicativeInstances.sml
@@ -1,0 +1,35 @@
+(* 第12章 アプリカティブのインスタンス (演習・解答で共通)．
+ * Validation は誤りを「蓄積」する．これはモナド (短絡する Either) では作れない
+ * アプリカティブ特有の振る舞い． *)
+
+structure OptionAp: APPLICATIVE =
+struct
+  type 'a t = 'a option
+  fun unit a = SOME a
+  fun map2 f (SOME a) (SOME b) =
+        SOME (f (a, b))
+    | map2 _ _ _ = NONE
+end
+
+structure ListAp: APPLICATIVE =
+struct
+  type 'a t = 'a list
+  fun unit a = [a]
+  fun map2 f xs ys =
+    List.concat (List.map (fn a => List.map (fn b => f (a, b)) ys) xs)
+end
+
+datatype ('e, 'a) validation = Invalid of 'e list | Valid of 'a
+
+(* 誤り型 e を固定してアプリカティブにする． *)
+functor ValidationAp (type e): APPLICATIVE =
+struct
+  type 'a t = (e, 'a) validation
+  fun unit a = Valid a
+  fun map2 f va vb =
+    case (va, vb) of
+      (Valid a, Valid b) => Valid (f (a, b))
+    | (Invalid e1, Invalid e2) => Invalid (e1 @ e2)
+    | (Invalid e1, _) => Invalid e1
+    | (_, Invalid e2) => Invalid e2
+end

--- a/fp-in-sml/src/ch12_applicative/answers/ApplicativeUtil.sml
+++ b/fp-in-sml/src/ch12_applicative/answers/ApplicativeUtil.sml
@@ -1,0 +1,24 @@
+(* 第12章 解答例 (ApplicativeUtil)．
+ * unit と map2 だけを持つ APPLICATIVE から，map や ap をファンクタで導出する． *)
+functor ApplicativeUtil(A: APPLICATIVE) =
+struct
+  open A
+
+  fun map f m =
+    map2 (fn (a, _) => f a) m (unit ())
+
+  fun ap fab fa =
+    map2 (fn (g, a) => g a) fab fa
+
+  fun product (fa, fb) =
+    map2 (fn x => x) fa fb
+
+  fun sequence ms =
+    List.foldr (fn (m, acc) => map2 (fn (x, xs) => x :: xs) m acc) (unit []) ms
+
+  fun traverse f xs =
+    sequence (List.map f xs)
+
+  fun replicateM n m =
+    sequence (List.tabulate (n, fn _ => m))
+end

--- a/fp-in-sml/src/ch12_applicative/exercises/ApplicativeUtil.sml
+++ b/fp-in-sml/src/ch12_applicative/exercises/ApplicativeUtil.sml
@@ -1,0 +1,14 @@
+(* 第12章 演習 (ApplicativeUtil)．
+ * unit と map2 だけから派生関数を導く functor． *)
+functor ApplicativeUtil(A: APPLICATIVE) =
+struct
+  open A
+
+  (* Exercise 12.x: unit / map2 だけを使って実装せよ． *)
+  fun map f m = Stub.todo ()
+  fun ap fab fa = Stub.todo ()
+  fun product (fa, fb) = Stub.todo ()
+  fun sequence ms = Stub.todo ()
+  fun traverse f xs = Stub.todo ()
+  fun replicateM n m = Stub.todo ()
+end

--- a/fp-in-sml/src/ch13_iomonad/MY_IO.sig
+++ b/fp-in-sml/src/ch13_iomonad/MY_IO.sig
@@ -1,0 +1,15 @@
+(* 第13章 IO モナド: 副作用を「記述」として値にし，run するまで実行を遅らせる．
+ * 'a io の中身 (unit -> 'a のサンク) は :> で隠す．
+ * effect で任意の副作用を IO に持ち上げ，run で実際に走らせる． *)
+signature MY_IO =
+sig
+  type 'a io
+
+  val unit: 'a -> 'a io
+  val flatMap: ('a -> 'b io) -> 'a io -> 'b io
+  val map: ('a -> 'b) -> 'a io -> 'b io
+  val sequence: 'a io list -> 'a list io
+
+  val effect: (unit -> 'a) -> 'a io (* 副作用を IO に持ち上げる *)
+  val run: 'a io -> 'a (* 効果を実行する *)
+end

--- a/fp-in-sml/src/ch13_iomonad/answers/MyIO.sml
+++ b/fp-in-sml/src/ch13_iomonad/answers/MyIO.sml
@@ -1,0 +1,23 @@
+(* 第13章 解答例 (MyIO)． *)
+structure MyIO :> MY_IO =
+struct
+  (* 「実行すると 'a を返す遅延計算」をサンク unit -> 'a で表す． *)
+  type 'a io = unit -> 'a
+
+  (* effect/run は封印した型の出入り口 (中身はサンクそのもの)． *)
+  fun effect th = th
+  fun run m = m ()
+
+  fun unit a = fn () => a
+
+  fun flatMap f m =
+    fn () => run (f (run m))
+
+  fun map f m =
+    fn () => f (run m)
+
+  (* 効果が左から右の順に走るよう，モナド的に合成する． *)
+  fun sequence ms =
+    List.foldr (fn (m, acc) => flatMap (fn x => map (fn xs => x :: xs) acc) m)
+      (unit []) ms
+end

--- a/fp-in-sml/src/ch13_iomonad/answers/MyIO.sml
+++ b/fp-in-sml/src/ch13_iomonad/answers/MyIO.sml
@@ -8,13 +8,13 @@ struct
   fun effect th = th
   fun run m = m ()
 
-  fun unit a = fn () => a
+  fun unit a () = a
 
-  fun flatMap f m =
-    fn () => run (f (run m))
+  fun flatMap f m () =
+    run (f (run m))
 
-  fun map f m =
-    fn () => f (run m)
+  fun map f m () =
+    f (run m)
 
   (* 効果が左から右の順に走るよう，モナド的に合成する． *)
   fun sequence ms =

--- a/fp-in-sml/src/ch13_iomonad/exercises/MyIO.sml
+++ b/fp-in-sml/src/ch13_iomonad/exercises/MyIO.sml
@@ -1,0 +1,15 @@
+(* 第13章 演習 (MyIO)．effect / run は提供済み．
+ * モナド操作は「サンク (fn () => ...) を返す」形なので，組み立て時には実行されない． *)
+structure MyIO :> MY_IO =
+struct
+  type 'a io = unit -> 'a
+
+  fun effect th = th
+  fun run m = m ()
+
+  (* Exercise 13.x: unit / flatMap / map / sequence を実装せよ． *)
+  fun unit a = fn () => Stub.todo ()
+  fun flatMap f m = fn () => Stub.todo ()
+  fun map f m = fn () => Stub.todo ()
+  fun sequence ms = fn () => Stub.todo ()
+end

--- a/fp-in-sml/src/ch13_iomonad/exercises/MyIO.sml
+++ b/fp-in-sml/src/ch13_iomonad/exercises/MyIO.sml
@@ -1,5 +1,4 @@
-(* 第13章 演習 (MyIO)．effect / run は提供済み．
- * モナド操作は「サンク (fn () => ...) を返す」形なので，組み立て時には実行されない． *)
+(* 第13章 演習 (MyIO)．effect / run は提供済み． *)
 structure MyIO :> MY_IO =
 struct
   type 'a io = unit -> 'a
@@ -8,8 +7,8 @@ struct
   fun run m = m ()
 
   (* Exercise 13.x: unit / flatMap / map / sequence を実装せよ． *)
-  fun unit a = fn () => Stub.todo ()
-  fun flatMap f m = fn () => Stub.todo ()
-  fun map f m = fn () => Stub.todo ()
-  fun sequence ms = fn () => Stub.todo ()
+  fun unit a () = Stub.todo ()
+  fun flatMap f m () = Stub.todo ()
+  fun map f m () = Stub.todo ()
+  fun sequence ms () = Stub.todo ()
 end

--- a/fp-in-sml/src/ch14_localeffects/LOCAL_EFFECTS.sig
+++ b/fp-in-sml/src/ch14_localeffects/LOCAL_EFFECTS.sig
@@ -1,0 +1,9 @@
+(* 第14章 局所的な副作用 (縮小版)．
+ * 本書: ST モナドで局所的可変を型に閉じ込め，外に漏れないことを保証する．
+ * SML: 関数内の ref / 配列で同じことが書けるため ST は扱わない．
+ * 代表例: 内部だけ可変配列で並べ替え，外からは int list -> int list の純関数． *)
+signature LOCAL_EFFECTS =
+sig
+  (* 外からは純粋 (同じ入力には同じ出力，副作用は観測されない)． *)
+  val quicksort: int list -> int list
+end

--- a/fp-in-sml/src/ch14_localeffects/answers/LocalEffects.sml
+++ b/fp-in-sml/src/ch14_localeffects/answers/LocalEffects.sml
@@ -1,0 +1,50 @@
+(* 第14章 解答例 (LocalEffects)．可変配列を関数の内部だけで使う． *)
+structure LocalEffects: LOCAL_EFFECTS =
+struct
+  fun quicksort [] = []
+    | quicksort xs =
+        let
+          val arr = Array.fromList xs
+          val n = Array.length arr
+
+          fun swap (i, j) =
+            let
+              val t = Array.sub (arr, i)
+            in
+              Array.update (arr, i, Array.sub (arr, j));
+              Array.update (arr, j, t)
+            end
+
+          (* Lomuto 分割．lo..hi の範囲を pivot = arr[hi] で分ける． *)
+          fun partition (lo, hi) =
+            let
+              val pivot = Array.sub (arr, hi)
+              val store = ref lo
+              fun loop j =
+                if j < hi then
+                  ( if Array.sub (arr, j) < pivot then
+                      (swap (!store, j); store := !store + 1)
+                    else
+                      ()
+                  ; loop (j + 1)
+                  )
+                else
+                  ()
+            in
+              loop lo;
+              swap (!store, hi);
+              !store
+            end
+
+          fun qs (lo, hi) =
+            if lo < hi then
+              let val p = partition (lo, hi)
+              in qs (lo, p - 1); qs (p + 1, hi)
+              end
+            else
+              ()
+        in
+          qs (0, n - 1);
+          Array.foldr (op::) [] arr
+        end
+end

--- a/fp-in-sml/src/ch14_localeffects/exercises/LocalEffects.sml
+++ b/fp-in-sml/src/ch14_localeffects/exercises/LocalEffects.sml
@@ -1,0 +1,8 @@
+(* 第14章 演習 (LocalEffects)． *)
+structure LocalEffects: LOCAL_EFFECTS =
+struct
+  (* Exercise 14.x: 内部で Array を使った in-place クイックソートを実装せよ．
+   * ヒント: Array.fromList で配列にし，添字で swap しながら整列し，
+   * 最後に Array.foldr (op ::) [] でリストへ戻す．可変状態は関数の外へ漏らさない． *)
+  fun quicksort xs = Stub.todo ()
+end

--- a/fp-in-sml/src/ch15_streamingio/PROCESS.sig
+++ b/fp-in-sml/src/ch15_streamingio/PROCESS.sig
@@ -1,0 +1,24 @@
+(* 第15章 ストリーム処理: 単純なトランスデューサ Process[I,O]．
+ * 入力 'i を順に受け取り ('o を Emit しながら) 変換していく状態機械．
+ *   Halt              … これ以上出力しない
+ *   Emit (o, rest)    … o を1つ出し，続きは rest
+ *   Await recv        … 次の入力 (NONE は入力終端) を待ち，recv で続きを決める
+ * apply で入力リストを流し込み，出力リストを得る． *)
+signature PROCESS =
+sig
+  datatype ('i, 'o) process =
+    Halt
+  | Emit of 'o * ('i, 'o) process
+  | Await of 'i option -> ('i, 'o) process
+
+  val apply: ('i, 'o) process -> 'i list -> 'o list
+
+  val lift: ('i -> 'o) -> ('i, 'o) process
+  val filter: ('i -> bool) -> ('i, 'i) process
+  val take: int -> ('i, 'i) process
+  val sum: (real, real) process (* 累積和 *)
+  val count: ('i, int) process (* 累積個数 *)
+
+  (* p1 を通してから p2 に流す合成 (本書の |>)． *)
+  val pipe: ('i, 'o) process -> ('o, 'p) process -> ('i, 'p) process
+end

--- a/fp-in-sml/src/ch15_streamingio/answers/Process.sml
+++ b/fp-in-sml/src/ch15_streamingio/answers/Process.sml
@@ -1,0 +1,52 @@
+(* 第15章 解答例 (Process)． *)
+structure Process: PROCESS =
+struct
+  datatype ('i, 'o) process =
+    Halt
+  | Emit of 'o * ('i, 'o) process
+  | Await of 'i option -> ('i, 'o) process
+
+  fun apply Halt _ = []
+    | apply (Emit (out, rest)) input =
+        out :: apply rest input
+    | apply (Await recv) [] =
+        apply (recv NONE) []
+    | apply (Await recv) (x :: xs) =
+        apply (recv (SOME x)) xs
+
+  fun lift f =
+    Await (fn NONE => Halt | SOME x => Emit (f x, lift f))
+
+  fun filter p =
+    Await
+      (fn NONE => Halt | SOME x => if p x then Emit (x, filter p) else filter p)
+
+  fun take n =
+    if n <= 0 then Halt
+    else Await (fn NONE => Halt | SOME x => Emit (x, take (n - 1)))
+
+  val sum =
+    let
+      fun go acc =
+        Await
+          (fn NONE => Halt | SOME x => let val s = acc + x in Emit (s, go s) end)
+    in
+      go 0.0
+    end
+
+  (* count は入力型 'i に多相．値制限を避けるため，束縛そのものを
+   * 構成子適用 Await (...) (非拡張的=一般化できる) にしておく． *)
+  fun countFrom n =
+    Await (fn NONE => Halt | SOME _ => Emit (n + 1, countFrom (n + 1)))
+  val count = Await (fn NONE => Halt | SOME _ => Emit (1, countFrom 1))
+
+  fun pipe p1 p2 =
+    case p2 of
+      Halt => Halt
+    | Emit (out, t2) => Emit (out, pipe p1 t2)
+    | Await recv2 =>
+        (case p1 of
+           Halt => pipe Halt (recv2 NONE)
+         | Emit (out, t1) => pipe t1 (recv2 (SOME out))
+         | Await recv1 => Await (fn i => pipe (recv1 i) p2))
+end

--- a/fp-in-sml/src/ch15_streamingio/exercises/Process.sml
+++ b/fp-in-sml/src/ch15_streamingio/exercises/Process.sml
@@ -1,6 +1,4 @@
-(* 第15章 演習 (Process)．apply (駆動部) は提供済み．
- * sum / count は「値」なので，読込時に落ちないよう Await でくるんでおく
- * (実際に駆動されたときに Todo を投げる)． *)
+(* 第15章 演習 (Process)．apply (駆動部) は提供済み． *)
 structure Process: PROCESS =
 struct
   datatype ('i, 'o) process =

--- a/fp-in-sml/src/ch15_streamingio/exercises/Process.sml
+++ b/fp-in-sml/src/ch15_streamingio/exercises/Process.sml
@@ -1,0 +1,27 @@
+(* 第15章 演習 (Process)．apply (駆動部) は提供済み．
+ * sum / count は「値」なので，読込時に落ちないよう Await でくるんでおく
+ * (実際に駆動されたときに Todo を投げる)． *)
+structure Process: PROCESS =
+struct
+  datatype ('i, 'o) process =
+    Halt
+  | Emit of 'o * ('i, 'o) process
+  | Await of 'i option -> ('i, 'o) process
+
+  fun apply p input =
+    case p of
+      Halt => []
+    | Emit (out, rest) => out :: apply rest input
+    | Await recv =>
+        (case input of
+           [] => apply (recv NONE) []
+         | x :: xs => apply (recv (SOME x)) xs)
+
+  (* Exercise 15.x: 以下を実装せよ． *)
+  fun lift f = Stub.todo ()
+  fun filter p = Stub.todo ()
+  fun take n = Stub.todo ()
+  val sum = Await (fn _ => Stub.todo ())
+  val count = Await (fn _ => Stub.todo ())
+  fun pipe p1 p2 = Stub.todo ()
+end

--- a/fp-in-sml/test/ch02_gettingstarted/IntroTest.sml
+++ b/fp-in-sml/test/ch02_gettingstarted/IntroTest.sml
@@ -1,0 +1,40 @@
+(* 第2章 テスト (Intro)． *)
+structure IntroTest =
+struct
+  val () = Test.register "ch02 Intro.fib" (fn () =>
+    let
+      val expected = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
+      fun loop (_, []) = ()
+        | loop (i, e :: es) =
+            (Test.assertEqual (Intro.fib i, e); loop (i + 1, es))
+    in
+      loop (0, expected)
+    end)
+
+  val () = Test.register "ch02 Intro.isSorted" (fn () =>
+    let
+      val le = fn (a: int, b: int) => a <= b
+    in
+      Test.assertBool "ascending" (Intro.isSorted ([1, 2, 3, 3, 5], le));
+      Test.assertBool "single" (Intro.isSorted ([42], le));
+      Test.assertBool "empty" (Intro.isSorted ([], le));
+      Test.assertBool "descending is not sorted" (not
+        (Intro.isSorted ([1, 3, 2], le)))
+    end)
+
+  val () = Test.register "ch02 Intro.curry/uncurry" (fn () =>
+    let
+      val add = fn (a: int, b: int) => a + b
+    in
+      Test.assertEqual (Intro.curry add 3 4, 7);
+      Test.assertEqual (Intro.uncurry (Intro.curry add) (5, 6), 11)
+    end)
+
+  val () = Test.register "ch02 Intro.compose" (fn () =>
+    let
+      val inc = fn (x: int) => x + 1
+      val dbl = fn (x: int) => x * 2
+    in
+      Test.assertEqual (Intro.compose inc dbl 10, 21)
+    end)
+end

--- a/fp-in-sml/test/ch03_datastructures/MyListTest.sml
+++ b/fp-in-sml/test/ch03_datastructures/MyListTest.sml
@@ -1,0 +1,110 @@
+(* 第3章 テスト (MyList)．Basis の list/List を参照実装に差分テスト． *)
+structure MyListTest =
+struct
+  fun showIntList xs =
+    "[" ^ String.concatWith "," (List.map Int.toString xs) ^ "]"
+
+  fun showPair (xs, ys) =
+    "(" ^ showIntList xs ^ ", " ^ showIntList ys ^ ")"
+
+  val intList = Pbt.list Pbt.int
+  val pairOfLists = Pbt.pair (intList, intList)
+
+  (* MyList.t を経由した結果 (Basis list) を返す補助 *)
+  fun via f xs =
+    MyList.toList (f (MyList.fromList xs))
+
+  val () = Test.register "ch03 MyList.length" (fn () =>
+    Test.forAll showIntList intList (fn xs =>
+      MyList.length (MyList.fromList xs) = List.length xs))
+
+  val () = Test.register "ch03 MyList.reverse" (fn () =>
+    Test.forAll showIntList intList (fn xs =>
+      via MyList.reverse xs = List.rev xs))
+
+  val () = Test.register "ch03 MyList.map" (fn () =>
+    Test.forAll showIntList intList (fn xs =>
+      via (MyList.map (fn x => x + 1)) xs = List.map (fn x => x + 1) xs))
+
+  val () = Test.register "ch03 MyList.filter" (fn () =>
+    Test.forAll showIntList intList (fn xs =>
+      via (MyList.filter (fn x => x mod 2 = 0)) xs
+      = List.filter (fn x => x mod 2 = 0) xs))
+
+  val () = Test.register "ch03 MyList.foldLeft" (fn () =>
+    Test.forAll showIntList intList (fn xs =>
+      MyList.foldLeft (MyList.fromList xs) 0 (fn (x, acc) => x - acc)
+      = List.foldl (fn (x, acc) => x - acc) 0 xs))
+
+  val () = Test.register "ch03 MyList.foldRight rebuild" (fn () =>
+    Test.forAll showIntList intList (fn xs =>
+      let
+        val rebuilt =
+          MyList.foldRight (MyList.fromList xs) MyList.Nil (fn (x, acc) =>
+            MyList.Cons (x, acc))
+      in
+        MyList.toList rebuilt = xs
+      end))
+
+  val () = Test.register "ch03 MyList.append" (fn () =>
+    Test.forAll showPair pairOfLists (fn (xs, ys) =>
+      MyList.toList (MyList.append (MyList.fromList xs) (MyList.fromList ys))
+      = xs @ ys))
+
+  val () = Test.register "ch03 MyList.concat" (fn () =>
+    let
+      val a = MyList.fromList [1, 2]
+      val b = MyList.fromList [3]
+      val c = MyList.fromList [4, 5]
+      val xss = MyList.fromList [a, b, c]
+    in
+      Test.assertEqual (MyList.toList (MyList.concat xss), [1, 2, 3, 4, 5])
+    end)
+
+  val () = Test.register "ch03 MyList.flatMap" (fn () =>
+    let
+      val xs = MyList.fromList [1, 2, 3]
+      val r = MyList.flatMap (fn x => MyList.fromList [x, x]) xs
+    in
+      Test.assertEqual (MyList.toList r, [1, 1, 2, 2, 3, 3])
+    end)
+
+  val () = Test.register "ch03 MyList.zipWith" (fn () =>
+    let
+      val r = MyList.zipWith (op+) (MyList.fromList [1, 2, 3])
+        (MyList.fromList [10, 20])
+    in
+      Test.assertEqual (MyList.toList r, [11, 22])
+    end)
+
+  val () = Test.register "ch03 MyList.drop/dropWhile/init/tail" (fn () =>
+    let
+      val xs = MyList.fromList [1, 2, 3, 4]
+    in
+      Test.assertEqual (MyList.toList (MyList.tail xs), [2, 3, 4]);
+      Test.assertEqual (MyList.toList (MyList.setHead 9 xs), [9, 2, 3, 4]);
+      Test.assertEqual (MyList.toList (MyList.drop 2 xs), [3, 4]);
+      Test.assertEqual
+        (MyList.toList (MyList.dropWhile (fn x => x < 3) xs), [3, 4]);
+      Test.assertEqual (MyList.toList (MyList.init xs), [1, 2, 3])
+    end)
+
+  val () = Test.register "ch03 MyList.sum/product" (fn () =>
+    ( Test.assertEqual (MyList.sum (MyList.fromList [1, 2, 3, 4]), 10)
+    ; Test.assertEqualBy
+        {eq = fn (a, b) => Real.abs (a - b) < 1.0E~9, show = Real.toString}
+        (MyList.product (MyList.fromList [2.0, 3.0, 4.0]), 24.0)
+    ))
+
+  val () = Test.register "ch03 MyList.hasSubsequence" (fn () =>
+    let
+      val sup = MyList.fromList [1, 2, 3, 4]
+    in
+      Test.assertBool "contains [2,3]" (MyList.hasSubsequence sup
+        (MyList.fromList [2, 3]));
+      Test.assertBool "contains []"
+        (MyList.hasSubsequence sup (MyList.fromList []));
+      Test.assertBool "not [3,2]" (not (MyList.hasSubsequence sup
+        (MyList.fromList [3, 2])))
+    end)
+end

--- a/fp-in-sml/test/ch03_datastructures/TreeTest.sml
+++ b/fp-in-sml/test/ch03_datastructures/TreeTest.sml
@@ -1,0 +1,24 @@
+(* 第3章 テスト (Tree)． *)
+structure TreeTest =
+struct
+  open Tree
+
+  (* (1 (2 3)) のような木 *)
+  val t = Branch (Leaf 1, Branch (Leaf 2, Leaf 3))
+
+  val () = Test.register "ch03 Tree.size" (fn () =>
+    Test.assertEqual (size t, 5))
+
+  val () = Test.register "ch03 Tree.depth" (fn () =>
+    Test.assertEqual (depth t, 2))
+
+  val () = Test.register "ch03 Tree.maximum" (fn () =>
+    Test.assertEqual (maximum t, 3))
+
+  val () = Test.register "ch03 Tree.map" (fn () =>
+    Test.assertEqual (map (fn x => x * 10) t, Branch
+      (Leaf 10, Branch (Leaf 20, Leaf 30))))
+
+  val () = Test.register "ch03 Tree.fold size == map then size" (fn () =>
+    Test.assertEqual (size (map (fn x => x + 1) t), size t))
+end

--- a/fp-in-sml/test/ch04_errorhandling/EitherTest.sml
+++ b/fp-in-sml/test/ch04_errorhandling/EitherTest.sml
@@ -1,0 +1,50 @@
+(* 第4章 テスト (Either)．(string, int) t は等値型なので assertEqual が使える． *)
+structure EitherTest =
+struct
+  open Either
+
+  val () = Test.register "ch04 Either.map" (fn () =>
+    ( Test.assertEqual
+        (map (fn x => x + 1) (Right 1), Right 2 : (string, int) t)
+    ; Test.assertEqual
+        (map (fn x => x + 1) (Left "e"), Left "e" : (string, int) t)
+    ))
+
+  val () = Test.register "ch04 Either.flatMap" (fn () =>
+    ( Test.assertEqual
+        (flatMap (fn x => Right (x * 2)) (Right 3), Right 6 : (string, int) t)
+    ; Test.assertEqual
+        (flatMap (fn x => Right (x * 2)) (Left "e"), Left "e" : (string, int) t)
+    ))
+
+  val () = Test.register "ch04 Either.orElse" (fn () =>
+    ( Test.assertEqual (orElse (Left "e") (Right 9), Right 9 : (string, int) t)
+    ; Test.assertEqual (orElse (Right 1) (Right 9), Right 1 : (string, int) t)
+    ))
+
+  val () = Test.register "ch04 Either.map2" (fn () =>
+    ( Test.assertEqual
+        (map2 (op+) (Right 3) (Right 4), Right 7 : (string, int) t)
+    ; Test.assertEqual
+        (map2 (op+) (Right 3) (Left "e"), Left "e" : (string, int) t)
+    ))
+
+  val () = Test.register "ch04 Either.sequence/traverse" (fn () =>
+    ( Test.assertEqual
+        ( sequence [Right 1, Right 2, Right 3]
+        , Right [1, 2, 3] : (string, int list) t
+        )
+    ; Test.assertEqual
+        ( sequence [Right 1, Left "boom", Right 3]
+        , Left "boom" : (string, int list) t
+        )
+    ; Test.assertEqual
+        ( traverse (fn x => if x >= 0 then Right x else Left "neg") [1, 2, 3]
+        , Right [1, 2, 3] : (string, int list) t
+        )
+    ; Test.assertEqual
+        ( traverse (fn x => if x >= 0 then Right x else Left "neg") [1, ~2, 3]
+        , Left "neg" : (string, int list) t
+        )
+    ))
+end

--- a/fp-in-sml/test/ch04_errorhandling/MyOptionTest.sml
+++ b/fp-in-sml/test/ch04_errorhandling/MyOptionTest.sml
@@ -1,0 +1,53 @@
+(* 第4章 テスト (MyOption)．Basis の Option を参照実装に差分テスト． *)
+structure MyOptionTest =
+struct
+  structure M = MyOption
+
+  fun showOpt NONE = "NONE"
+    | showOpt (SOME n) = "SOME " ^ Int.toString n
+
+  fun showOptList os =
+    "[" ^ String.concatWith "," (List.map showOpt os) ^ "]"
+
+  (* int option のジェネレータ *)
+  val optGen = Pbt.bind Pbt.bool (fn b =>
+    if b then Pbt.map SOME Pbt.int else Pbt.map (fn _ => NONE) Pbt.int)
+
+  fun seqRef os =
+    List.foldr
+      (fn (NONE, _) => NONE
+        | (_, NONE) => NONE
+        | (SOME x, SOME acc) => SOME (x :: acc)) (SOME []) os
+
+  val () = Test.register "ch04 MyOption.map" (fn () =>
+    Test.forAll showOpt optGen (fn opt =>
+      M.toOption (M.map (fn x => x + 1) (M.fromOption opt))
+      = Option.map (fn x => x + 1) opt))
+
+  val () = Test.register "ch04 MyOption.getOrElse" (fn () =>
+    Test.forAll showOpt optGen (fn opt =>
+      M.getOrElse (M.fromOption opt) 0 = Option.getOpt (opt, 0)))
+
+  val () = Test.register "ch04 MyOption.flatMap/orElse/filter" (fn () =>
+    ( Test.assertEqual
+        (M.toOption (M.flatMap (fn x => M.Some (x * 2)) (M.Some 3)), SOME 6)
+    ; Test.assertEqual
+        (M.toOption (M.flatMap (fn x => M.Some (x * 2)) M.None), NONE)
+    ; Test.assertEqual (M.toOption (M.orElse M.None (M.Some 5)), SOME 5)
+    ; Test.assertEqual (M.toOption (M.orElse (M.Some 1) (M.Some 5)), SOME 1)
+    ; Test.assertEqual
+        (M.toOption (M.filter (fn x => x > 0) (M.Some 3)), SOME 3)
+    ; Test.assertEqual (M.toOption (M.filter (fn x => x > 0) (M.Some ~3)), NONE)
+    ))
+
+  val () = Test.register "ch04 MyOption.map2" (fn () =>
+    ( Test.assertEqual (M.toOption (M.map2 (op+) (M.Some 3) (M.Some 4)), SOME 7)
+    ; Test.assertEqual (M.toOption (M.map2 (op+) (M.Some 3) M.None), NONE)
+    ))
+
+  val () = Test.register "ch04 MyOption.sequence" (fn () =>
+    Test.forAll showOptList (Pbt.list optGen) (fn os =>
+      let val got = M.toOption (M.sequence (List.map M.fromOption os))
+      in got = seqRef os
+      end))
+end

--- a/fp-in-sml/test/ch05_laziness/LazyListTest.sml
+++ b/fp-in-sml/test/ch05_laziness/LazyListTest.sml
@@ -1,0 +1,71 @@
+(* 第5章 テスト (LazyList)．無限列は take してから toList で確かめる． *)
+structure LazyListTest =
+struct
+  structure L = LazyList
+
+  fun showIntList xs =
+    "[" ^ String.concatWith "," (List.map Int.toString xs) ^ "]"
+
+  val intList = Pbt.list Pbt.int
+
+  val () = Test.register "ch05 LazyList.toList/fromList round trip" (fn () =>
+    Test.forAll showIntList intList (fn xs => L.toList (L.fromList xs) = xs))
+
+  val () = Test.register "ch05 LazyList.take" (fn () =>
+    Test.assertEqual
+      (L.toList (L.take 3 (L.fromList [1, 2, 3, 4, 5])), [1, 2, 3]))
+
+  val () = Test.register "ch05 LazyList.drop" (fn () =>
+    Test.assertEqual
+      (L.toList (L.drop 2 (L.fromList [1, 2, 3, 4, 5])), [3, 4, 5]))
+
+  val () = Test.register "ch05 LazyList.takeWhile" (fn () =>
+    Test.assertEqual
+      (L.toList (L.takeWhile (fn x => x < 3) (L.fromList [1, 2, 3, 1])), [1, 2]))
+
+  val () = Test.register "ch05 LazyList.headOption" (fn () =>
+    ( Test.assertEqual (L.headOption (L.fromList [9, 8]), SOME 9)
+    ; Test.assertEqual (L.headOption (L.fromList ([] : int list)), NONE)
+    ))
+
+  val () = Test.register "ch05 LazyList.exists/forAll" (fn () =>
+    let
+      val s = L.fromList [2, 4, 6]
+    in
+      Test.assertBool "exists even" (L.exists (fn x => x mod 2 = 0) s);
+      Test.assertBool "all even" (L.forAll (fn x => x mod 2 = 0) s);
+      Test.assertBool "not all > 4" (not (L.forAll (fn x => x > 4) s))
+    end)
+
+  val () = Test.register "ch05 LazyList.map/filter" (fn () =>
+    Test.forAll showIntList intList (fn xs =>
+      L.toList (L.map (fn x => x + 1) (L.fromList xs))
+      = List.map (fn x => x + 1) xs
+      andalso
+      L.toList (L.filter (fn x => x mod 2 = 0) (L.fromList xs))
+      = List.filter (fn x => x mod 2 = 0) xs))
+
+  val () = Test.register "ch05 LazyList.append/flatMap" (fn () =>
+    ( Test.assertEqual
+        ( L.toList (L.append (L.fromList [1, 2]) (fn () => L.fromList [3, 4]))
+        , [1, 2, 3, 4]
+        )
+    ; Test.assertEqual
+        ( L.toList (L.flatMap (fn x => L.fromList [x, x]) (L.fromList [1, 2]))
+        , [1, 1, 2, 2]
+        )
+    ))
+
+  val () = Test.register "ch05 LazyList.constant/from/fibs (infinite)" (fn () =>
+    ( Test.assertEqual (L.toList (L.take 4 (L.constant 7)), [7, 7, 7, 7])
+    ; Test.assertEqual (L.toList (L.take 5 (L.from 10)), [10, 11, 12, 13, 14])
+    ; Test.assertEqual (L.toList (L.take 7 (L.fibs ())), [0, 1, 1, 2, 3, 5, 8])
+    ))
+
+  val () = Test.register "ch05 LazyList.unfold" (fn () =>
+    Test.assertEqual
+      ( L.toList (L.unfold 0 (fn n =>
+          if n < 5 then SOME (n * n, n + 1) else NONE))
+      , [0, 1, 4, 9, 16]
+      ))
+end

--- a/fp-in-sml/test/ch06_state/RngTest.sml
+++ b/fp-in-sml/test/ch06_state/RngTest.sml
@@ -1,0 +1,45 @@
+(* 第6章 テスト (Rng)．乱数なので「性質」と「再現性」を確かめる． *)
+structure RngTest =
+struct
+  structure R = Rng
+
+  fun showInt n = Int.toString n
+
+  val () = Test.register "ch06 Rng deterministic" (fn () =>
+    let
+      val (a, _) = R.nextInt (R.simple 42)
+      val (b, _) = R.nextInt (R.simple 42)
+    in
+      Test.assertEqual (a, b)
+    end)
+
+  val () = Test.register "ch06 Rng.nonNegativeInt >= 0" (fn () =>
+    Test.forAll showInt Pbt.int (fn seed =>
+      let val (n, _) = R.nonNegativeInt (R.simple seed)
+      in n >= 0
+      end))
+
+  val () = Test.register "ch06 Rng.double in [0,1)" (fn () =>
+    Test.forAll showInt Pbt.int (fn seed =>
+      let val (d, _) = R.double (R.simple seed)
+      in d >= 0.0 andalso d < 1.0
+      end))
+
+  val () = Test.register "ch06 Rng.ints length" (fn () =>
+    let val (xs, _) = R.ints 5 (R.simple 1)
+    in Test.assertEqual (List.length xs, 5)
+    end)
+
+  val () = Test.register "ch06 Rng.map" (fn () =>
+    let
+      val rb = R.map (fn n => n mod 2) R.nonNegativeInt
+      val (v, _) = rb (R.simple 7)
+    in
+      Test.assertBool "0 or 1" (v = 0 orelse v = 1)
+    end)
+
+  val () = Test.register "ch06 Rng.sequence/unit" (fn () =>
+    let val (xs, _) = R.sequence [R.unit 1, R.unit 2, R.unit 3] (R.simple 1)
+    in Test.assertEqual (xs, [1, 2, 3])
+    end)
+end

--- a/fp-in-sml/test/ch06_state/StateTest.sml
+++ b/fp-in-sml/test/ch06_state/StateTest.sml
@@ -1,0 +1,44 @@
+(* 第6章 テスト (State)． *)
+structure StateTest =
+struct
+  structure S = State
+
+  val () = Test.register "ch06 State get/set" (fn () =>
+    let
+      val prog =
+        S.flatMap (fn x => S.flatMap (fn _ => S.unit x) (S.set (x + 1))) S.get
+      val (a, s) = S.run prog 10
+    in
+      Test.assertEqual ((a, s), (10, 11))
+    end)
+
+  val () = Test.register "ch06 State.modify" (fn () =>
+    let val (_, s) = S.run (S.modify (fn n => n * 2)) 21
+    in Test.assertEqual (s, 42)
+    end)
+
+  val () = Test.register "ch06 State.map2" (fn () =>
+    let
+      val p = S.map2 (op+) (S.unit 3) (S.unit 4)
+      val (a, _) = S.run p 0
+    in
+      Test.assertEqual (a, 7)
+    end)
+
+  val () = Test.register "ch06 State.sequence" (fn () =>
+    let
+      val p = S.sequence [S.unit 1, S.unit 2, S.unit 3]
+      val (xs, _) = S.run p 0
+    in
+      Test.assertEqual (xs, [1, 2, 3])
+    end)
+
+  val () = Test.register "ch06 State counter via sequence" (fn () =>
+    let
+      val tick = S.flatMap (fn n => S.map (fn _ => n) (S.set (n + 1))) S.get
+      val p = S.sequence [tick, tick, tick]
+      val (xs, s) = S.run p 0
+    in
+      Test.assertEqual ((xs, s), ([0, 1, 2], 3))
+    end)
+end

--- a/fp-in-sml/test/ch08_testing/GenTest.sml
+++ b/fp-in-sml/test/ch08_testing/GenTest.sml
@@ -1,0 +1,45 @@
+(* 第8章 テスト (Gen)．サンプリングした値の性質を確かめる． *)
+structure GenTest =
+struct
+  structure G = Gen
+
+  val seed = Rng.simple 1234
+
+  val () = Test.register "ch08 Gen.unit" (fn () =>
+    let val (v, _) = G.sample (G.unit 99) seed
+    in Test.assertEqual (v, 99)
+    end)
+
+  val () = Test.register "ch08 Gen.choose in range" (fn () =>
+    let
+      fun loop (0, _) = true
+        | loop (k, r) =
+            let val (n, r') = G.sample (G.choose (10, 20)) r
+            in n >= 10 andalso n < 20 andalso loop (k - 1, r')
+            end
+    in
+      Test.assertBool "all in [10,20)" (loop (100, seed))
+    end)
+
+  val () = Test.register "ch08 Gen.listOfN length" (fn () =>
+    let val (xs, _) = G.sample (G.listOfN 5 (G.unit 0)) seed
+    in Test.assertEqual (List.length xs, 5)
+    end)
+
+  val () = Test.register "ch08 Gen.pair" (fn () =>
+    let val ((a, b), _) = G.sample (G.pair (G.unit 1) (G.unit 2)) seed
+    in Test.assertEqual ((a, b), (1, 2))
+    end)
+
+  val () = Test.register "ch08 Gen.union picks from both" (fn () =>
+    let
+      fun loop (0, _, seenA, seenB) = (seenA, seenB)
+        | loop (k, r, seenA, seenB) =
+            let val (v, r') = G.sample (G.union (G.unit 1) (G.unit 2)) r
+            in loop (k - 1, r', seenA orelse v = 1, seenB orelse v = 2)
+            end
+      val (seenA, seenB) = loop (50, seed, false, false)
+    in
+      Test.assertBool "saw both 1 and 2" (seenA andalso seenB)
+    end)
+end

--- a/fp-in-sml/test/ch08_testing/PropTest.sml
+++ b/fp-in-sml/test/ch08_testing/PropTest.sml
@@ -1,0 +1,35 @@
+(* 第8章 テスト (Prop)．自作 Prop が成功/失敗を正しく判定するか． *)
+structure PropTest =
+struct
+  structure P = Prop
+
+  val seed = Rng.simple 99
+
+  val () = Test.register "ch08 Prop true property passes" (fn () =>
+    let
+      val prop = P.forAll (Gen.choose (0, 100)) Int.toString (fn n =>
+        n >= 0 andalso n < 100)
+    in
+      Test.assertBool "Passed" (P.isPassed (P.run prop 100 seed))
+    end)
+
+  val () = Test.register "ch08 Prop false property fails" (fn () =>
+    let
+      val prop = P.forAll (Gen.unit 5) Int.toString (fn n => n <> 5)
+    in
+      case P.run prop 100 seed of
+        P.Falsified s => Test.assertEqual (s, "5")
+      | P.Passed => Test.assertBool "should have falsified" false
+    end)
+
+  val () = Test.register "ch08 Prop andProp" (fn () =>
+    let
+      val good = P.forAll (Gen.choose (0, 10)) Int.toString (fn n => n < 10)
+      val bad = P.forAll (Gen.unit 1) Int.toString (fn _ => false)
+    in
+      Test.assertBool "good && good passes" (P.isPassed
+        (P.run (P.andProp (good, good)) 50 seed));
+      Test.assertBool "good && bad fails" (not (P.isPassed
+        (P.run (P.andProp (good, bad)) 50 seed)))
+    end)
+end

--- a/fp-in-sml/test/ch09_parsing/JsonTest.sml
+++ b/fp-in-sml/test/ch09_parsing/JsonTest.sml
@@ -1,0 +1,56 @@
+(* 第9章 テスト (Json)．json は real を含み等値型でないので独自 eq/show で比較． *)
+structure JsonTest =
+struct
+  open Json
+
+  fun jsonEq (JNull, JNull) = true
+    | jsonEq (JBool a, JBool b) = a = b
+    | jsonEq (JNumber a, JNumber b) =
+        Real.abs (a - b) < 1.0E~9
+    | jsonEq (JString a, JString b) = a = b
+    | jsonEq (JArray a, JArray b) = ListPair.allEq jsonEq (a, b)
+    | jsonEq (JObject a, JObject b) =
+        ListPair.allEq
+          (fn ((k1, v1), (k2, v2)) => k1 = k2 andalso jsonEq (v1, v2)) (a, b)
+    | jsonEq _ = false
+
+  fun jsonShow JNull = "null"
+    | jsonShow (JBool b) = Bool.toString b
+    | jsonShow (JNumber r) = Real.toString r
+    | jsonShow (JString s) = "\"" ^ s ^ "\""
+    | jsonShow (JArray xs) =
+        "[" ^ String.concatWith "," (List.map jsonShow xs) ^ "]"
+    | jsonShow (JObject ps) =
+        "{"
+        ^
+        String.concatWith ","
+          (List.map (fn (k, v) => "\"" ^ k ^ "\":" ^ jsonShow v) ps) ^ "}"
+
+  fun checkParse (input, expected) =
+    case Json.parse input of
+      Parser.Success j =>
+        Test.assertEqualBy {eq = jsonEq, show = jsonShow} (j, expected)
+    | Parser.Failure m => Test.assertBool ("parse failed: " ^ m) false
+
+  val () = Test.register "ch09 Json scalars" (fn () =>
+    ( checkParse ("null", JNull)
+    ; checkParse ("true", JBool true)
+    ; checkParse ("false", JBool false)
+    ; checkParse ("42", JNumber 42.0)
+    ; checkParse ("3.14", JNumber 3.14)
+    ; checkParse ("\"hello\"", JString "hello")
+    ))
+
+  val () = Test.register "ch09 Json with whitespace" (fn () =>
+    checkParse ("   true   ", JBool true))
+
+  val () = Test.register "ch09 Json array" (fn () =>
+    checkParse ("[1, 2, 3]", JArray [JNumber 1.0, JNumber 2.0, JNumber 3.0]))
+
+  val () = Test.register "ch09 Json nested object" (fn () =>
+    checkParse ("{\"a\": 1, \"b\": [true, null]}", JObject
+      [("a", JNumber 1.0), ("b", JArray [JBool true, JNull])]))
+
+  val () = Test.register "ch09 Json empty array/object" (fn () =>
+    (checkParse ("[]", JArray []); checkParse ("{}", JObject [])))
+end

--- a/fp-in-sml/test/ch09_parsing/ParserTest.sml
+++ b/fp-in-sml/test/ch09_parsing/ParserTest.sml
@@ -1,0 +1,53 @@
+(* 第9章 テスト (Parser)．結果は等値型なので assertEqual が使える． *)
+structure ParserTest =
+struct
+  structure P = Parser
+
+  val () = Test.register "ch09 Parser.char" (fn () =>
+    Test.assertEqual (P.run (P.char #"a") "abc", P.Success #"a"))
+
+  val () = Test.register "ch09 Parser.string" (fn () =>
+    ( Test.assertEqual (P.run (P.string "ab") "abc", P.Success "ab")
+    ; case P.run (P.string "xy") "abc" of
+        P.Failure _ => ()
+      | P.Success _ => Test.assertBool "should fail" false
+    ))
+
+  val () = Test.register "ch09 Parser.or" (fn () =>
+    ( Test.assertEqual
+        (P.run (P.or (P.string "x", P.string "ab")) "ab", P.Success "ab")
+    ; Test.assertEqual
+        (P.run (P.or (P.string "ab", P.string "x")) "ab", P.Success "ab")
+    ))
+
+  val () = Test.register "ch09 Parser.many" (fn () =>
+    Test.assertEqual
+      (P.run (P.many (P.char #"a")) "aaab", P.Success [#"a", #"a", #"a"]))
+
+  val () = Test.register "ch09 Parser.many1 fails on zero" (fn () =>
+    case P.run (P.many1 (P.char #"a")) "bbb" of
+      P.Failure _ => ()
+    | P.Success _ => Test.assertBool "should fail" false)
+
+  val () = Test.register "ch09 Parser.map2/product" (fn () =>
+    Test.assertEqual
+      ( P.run (P.product (P.char #"a", P.char #"b")) "abc"
+      , P.Success (#"a", #"b")
+      ))
+
+  val () = Test.register "ch09 Parser.satisfy digit" (fn () =>
+    Test.assertEqual
+      ( P.run (P.many1 (P.satisfy Char.isDigit)) "123x"
+      , P.Success [#"1", #"2", #"3"]
+      ))
+
+  val () = Test.register "ch09 Parser.sepBy" (fn () =>
+    Test.assertEqual
+      ( P.run (P.sepBy (P.satisfy Char.isDigit) (P.char #",")) "1,2,3"
+      , P.Success [#"1", #"2", #"3"]
+      ))
+
+  val () = Test.register "ch09 Parser.listOfN" (fn () =>
+    Test.assertEqual
+      (P.run (P.listOfN 3 (P.char #"a")) "aaaa", P.Success [#"a", #"a", #"a"]))
+end

--- a/fp-in-sml/test/ch10_monoids/MonoidsTest.sml
+++ b/fp-in-sml/test/ch10_monoids/MonoidsTest.sml
@@ -1,0 +1,33 @@
+(* 第10章 テスト (モノイド)．functor を各インスタンスに適用して派生関数を試す． *)
+structure MonoidsTest =
+struct
+  structure IntAddOps = MonoidOps(IntAdd)
+  structure IntMulOps = MonoidOps(IntMul)
+  structure StrOps = MonoidOps(StringM)
+  structure OrOps = MonoidOps(BoolOr)
+  structure AndOps = MonoidOps(BoolAnd)
+
+  val () = Test.register "ch10 intAddition concatenate" (fn () =>
+    Test.assertEqual (IntAddOps.concatenate [1, 2, 3, 4], 10))
+
+  val () = Test.register "ch10 intMultiplication concatenate" (fn () =>
+    Test.assertEqual (IntMulOps.concatenate [1, 2, 3, 4], 24))
+
+  val () = Test.register "ch10 string concatenate" (fn () =>
+    Test.assertEqual (StrOps.concatenate ["a", "b", "c"], "abc"))
+
+  val () = Test.register "ch10 foldMap" (fn () =>
+    Test.assertEqual (IntAddOps.foldMap (fn x => x * 2) [1, 2, 3], 12))
+
+  val () = Test.register "ch10 boolean monoids" (fn () =>
+    ( Test.assertBool "or true" (OrOps.concatenate [false, false, true])
+    ; Test.assertBool "or empty false" (not (OrOps.concatenate []))
+    ; Test.assertBool "and true" (AndOps.concatenate [true, true, true])
+    ; Test.assertBool "and empty true" (AndOps.concatenate [])
+    ))
+
+  val () = Test.register "ch10 empty is identity" (fn () =>
+    ( Test.assertEqual (IntAdd.combine (IntAdd.empty, 5), 5)
+    ; Test.assertEqual (IntAdd.combine (5, IntAdd.empty), 5)
+    ))
+end

--- a/fp-in-sml/test/ch11_monads/MonadTest.sml
+++ b/fp-in-sml/test/ch11_monads/MonadTest.sml
@@ -1,0 +1,53 @@
+(* 第11章 テスト (Monad)．MonadUtil を各インスタンスに適用して派生関数を確かめる． *)
+structure MonadTest =
+struct
+  structure OptU = MonadUtil(OptionMonad)
+  structure ListU = MonadUtil(ListMonad)
+  structure IntState = StateMonadFn(type s = int)
+  structure StateU = MonadUtil(IntState)
+
+  val () = Test.register "ch11 Option map/map2" (fn () =>
+    ( Test.assertEqual (OptU.map (fn x => x + 1) (SOME 3), SOME 4)
+    ; Test.assertEqual (OptU.map2 (op+) (SOME 3) (SOME 4), SOME 7)
+    ; Test.assertEqual (OptU.map2 (op+) (SOME 3) NONE, NONE : int option)
+    ))
+
+  val () = Test.register "ch11 Option sequence" (fn () =>
+    ( Test.assertEqual (OptU.sequence [SOME 1, SOME 2, SOME 3], SOME [1, 2, 3])
+    ; Test.assertEqual
+        (OptU.sequence [SOME 1, NONE, SOME 3], NONE : int list option)
+    ))
+
+  val () = Test.register "ch11 Option join" (fn () =>
+    ( Test.assertEqual (OptU.join (SOME (SOME 5)), SOME 5)
+    ; Test.assertEqual (OptU.join (SOME NONE), NONE : int option)
+    ))
+
+  val () = Test.register "ch11 List map/sequence (cartesian)" (fn () =>
+    ( Test.assertEqual (ListU.map (fn x => x * 2) [1, 2, 3], [2, 4, 6])
+    ; Test.assertEqual (ListU.sequence [[1, 2], [3]], [[1, 3], [2, 3]])
+    ))
+
+  val () = Test.register "ch11 List replicateM" (fn () =>
+    Test.assertEqual
+      (ListU.replicateM 2 [0, 1], [[0, 0], [0, 1], [1, 0], [1, 1]]))
+
+  val () = Test.register "ch11 State monad via MonadUtil" (fn () =>
+    let
+      val prog = StateU.map2 (op+) (State.unit 3) (State.unit 4)
+      val (a, _) = State.run prog 0
+    in
+      Test.assertEqual (a, 7)
+    end)
+
+  val () = Test.register "ch11 State sequence threads state" (fn () =>
+    let
+      val tick =
+        State.flatMap (fn n => State.map (fn _ => n) (State.set (n + 1)))
+          State.get
+      val prog = StateU.sequence [tick, tick, tick]
+      val (xs, s) = State.run prog 0
+    in
+      Test.assertEqual ((xs, s), ([0, 1, 2], 3))
+    end)
+end

--- a/fp-in-sml/test/ch12_applicative/ApplicativeTest.sml
+++ b/fp-in-sml/test/ch12_applicative/ApplicativeTest.sml
@@ -1,0 +1,37 @@
+(* 第12章 テスト (Applicative)．Validation が誤りを蓄積することも確かめる． *)
+structure ApplicativeTest =
+struct
+  structure OptU = ApplicativeUtil(OptionAp)
+  structure ListU = ApplicativeUtil(ListAp)
+  structure StrVal = ValidationAp(type e = string)
+  structure ValU = ApplicativeUtil(StrVal)
+
+  val () = Test.register "ch12 Option map/sequence" (fn () =>
+    ( Test.assertEqual (OptU.map (fn x => x + 1) (SOME 3), SOME 4)
+    ; Test.assertEqual (OptU.sequence [SOME 1, SOME 2, SOME 3], SOME [1, 2, 3])
+    ; Test.assertEqual
+        (OptU.sequence [SOME 1, NONE, SOME 3], NONE : int list option)
+    ))
+
+  val () = Test.register "ch12 List ap (cartesian)" (fn () =>
+    Test.assertEqual
+      (ListU.ap [fn x => x + 1, fn x => x * 10] [1, 2], [2, 3, 10, 20]))
+
+  val () = Test.register "ch12 Validation success" (fn () =>
+    Test.assertEqual
+      ( ValU.sequence [Valid 1, Valid 2, Valid 3]
+      , Valid [1, 2, 3] : (string, int list) validation
+      ))
+
+  val () = Test.register "ch12 Validation accumulates errors" (fn () =>
+    Test.assertEqual
+      ( ValU.sequence [Valid 1, Invalid ["e1"], Invalid ["e2"]]
+      , Invalid ["e1", "e2"] : (string, int list) validation
+      ))
+
+  val () = Test.register "ch12 Validation map2 accumulates" (fn () =>
+    Test.assertEqual
+      ( StrVal.map2 (fn (x, _) => x) (Invalid ["a"]) (Invalid ["b"])
+      , Invalid ["a", "b"] : (string, int) validation
+      ))
+end

--- a/fp-in-sml/test/ch13_iomonad/MyIOTest.sml
+++ b/fp-in-sml/test/ch13_iomonad/MyIOTest.sml
@@ -1,0 +1,32 @@
+(* 第13章 テスト (MyIO)．ref を観測して「run するまで効果が起きない」ことを確かめる． *)
+structure MyIOTest =
+struct
+  val () = Test.register "ch13 IO defers effects until run" (fn () =>
+    let
+      val log = ref ([] : int list)
+      fun push x =
+        MyIO.effect (fn () => log := x :: !log)
+      val prog =
+        MyIO.flatMap (fn _ => MyIO.flatMap (fn _ => MyIO.unit 99) (push 2))
+          (push 1)
+    in
+      Test.assertEqual (!log, []); (* まだ何も起きていない *)
+      Test.assertEqual (MyIO.run prog, 99);
+      Test.assertEqual
+        (!log, [2, 1]) (* run して初めて効果が起きる *)
+    end)
+
+  val () = Test.register "ch13 IO map" (fn () =>
+    Test.assertEqual (MyIO.run (MyIO.map (fn x => x + 1) (MyIO.unit 10)), 11))
+
+  val () = Test.register "ch13 IO sequence runs left to right" (fn () =>
+    let
+      val log = ref ([] : int list)
+      fun push x =
+        MyIO.effect (fn () => (log := x :: !log; x))
+      val xs = MyIO.run (MyIO.sequence [push 1, push 2, push 3])
+    in
+      Test.assertEqual (xs, [1, 2, 3]);
+      Test.assertEqual (!log, [3, 2, 1])
+    end)
+end

--- a/fp-in-sml/test/ch14_localeffects/LocalEffectsTest.sml
+++ b/fp-in-sml/test/ch14_localeffects/LocalEffectsTest.sml
@@ -1,0 +1,27 @@
+(* 第14章 テスト (LocalEffects)．参照実装 (挿入ソート) との差分で検証． *)
+structure LocalEffectsTest =
+struct
+  fun showIntList xs =
+    "[" ^ String.concatWith "," (List.map Int.toString xs) ^ "]"
+
+  fun insert (x, []) = [x]
+    | insert (x, y :: ys) =
+        if x <= y then x :: y :: ys else y :: insert (x, ys)
+  fun refSort xs =
+    List.foldr insert [] xs
+
+  val () = Test.register "ch14 quicksort example" (fn () =>
+    Test.assertEqual
+      ( LocalEffects.quicksort [3, 1, 4, 1, 5, 9, 2, 6]
+      , [1, 1, 2, 3, 4, 5, 6, 9]
+      ))
+
+  val () = Test.register "ch14 quicksort empty/singleton" (fn () =>
+    ( Test.assertEqual (LocalEffects.quicksort [], [])
+    ; Test.assertEqual (LocalEffects.quicksort [42], [42])
+    ))
+
+  val () = Test.register "ch14 quicksort matches reference sort" (fn () =>
+    Test.forAll showIntList (Pbt.list Pbt.int) (fn xs =>
+      LocalEffects.quicksort xs = refSort xs))
+end

--- a/fp-in-sml/test/ch15_streamingio/ProcessTest.sml
+++ b/fp-in-sml/test/ch15_streamingio/ProcessTest.sml
@@ -1,0 +1,35 @@
+(* 第15章 テスト (Process)．apply で入力を流し，出力リストを確かめる． *)
+structure ProcessTest =
+struct
+  structure P = Process
+
+  fun realListEq (xs, ys) =
+    ListPair.allEq (fn (a, b) => Real.abs (a - b) < 1.0E~9) (xs, ys)
+  fun realListShow xs =
+    "[" ^ String.concatWith "," (List.map Real.toString xs) ^ "]"
+
+  val () = Test.register "ch15 Process.lift" (fn () =>
+    Test.assertEqual (P.apply (P.lift (fn x => x + 1)) [1, 2, 3], [2, 3, 4]))
+
+  val () = Test.register "ch15 Process.filter" (fn () =>
+    Test.assertEqual
+      (P.apply (P.filter (fn x => x mod 2 = 0)) [1, 2, 3, 4], [2, 4]))
+
+  val () = Test.register "ch15 Process.take" (fn () =>
+    Test.assertEqual (P.apply (P.take 2) [1, 2, 3, 4], [1, 2]))
+
+  val () = Test.register "ch15 Process.sum (running)" (fn () =>
+    Test.assertEqualBy {eq = realListEq, show = realListShow}
+      (P.apply P.sum [1.0, 2.0, 3.0], [1.0, 3.0, 6.0]))
+
+  val () = Test.register "ch15 Process.count" (fn () =>
+    Test.assertEqual (P.apply P.count [#"a", #"b", #"c"], [1, 2, 3]))
+
+  val () = Test.register "ch15 Process.pipe (compose)" (fn () =>
+    Test.assertEqual
+      ( P.apply
+          (P.pipe (P.lift (fn x => x + 1)) (P.filter (fn x => x mod 2 = 0)))
+          [1, 2, 3, 4]
+      , [2, 4]
+      ))
+end


### PR DESCRIPTION
# 新規言語を追加する場合

## 追加している内容とその理由

Standard ML 版のハンズオン教材 `fp-in-sml/` を追加します．

FP in Scala の各章を SML のモジュールシステムで実装する形で，章ごとにシグネチャ，演習，解答例，テストを備えています．

MLton と SML/NJ の両方でビルド → テストできます．CI や簡単な SML 入門 (`docs/sml-primer.md`) も同梱します．

収録章は 2 〜 6, 8 〜15 章です．7 章 (parallelism) は並行 API が処理系ごとに異なるため除外しています．第 14 章 (localeffects) は ST モナドを扱わずにクイックソートに絞っています．詳細は README に記載しています．

## チェックリスト

- [x] [CONTRIBUTING.md](https://github.com/fp-matsuri/fp-in-scala-exercises/blob/main/CONTRIBUTING.md)の問題作成方針に沿って作成した
- [x] 不要な(自動生成)ファイルが含まれないように適切に `.gitignore` されている
- [x] [テストコードがある場合] `exercises` 配下に `answers` 相当の解答例を反映するとすべてのテストケースがパスする
    - ℹ️ テストコードで指定しているテスト対象モジュールを `exercises` から `answers` のものに切り替えて試すのが楽かも
- [x] [リンター/フォーマッターがある場合] `exercises` 配下の未実装箇所周辺(演習問題のための未使用変数/関数など)を除いてすべてのチェックがパスする
