### PR TITLE
VS Code拡張からmise管理ツールを解決できるようにremoteEnvを設定

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,10 @@
   "containerEnv": {
     "MISE_TRUSTED_CONFIG_PATHS": "/workspaces"
   },
+  "remoteEnv": {
+    "PATH": "/home/vscode/.local/share/mise/shims:/home/vscode/.opam/default/bin:${containerEnv:PATH}",
+    "MISE_GLOBAL_CONFIG_FILE": "${containerWorkspaceFolder}/mise.toml"
+  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/local-build/devcontainer.json
+++ b/.devcontainer/local-build/devcontainer.json
@@ -8,6 +8,10 @@
   "containerEnv": {
     "MISE_TRUSTED_CONFIG_PATHS": "/workspaces"
   },
+  "remoteEnv": {
+    "PATH": "/home/vscode/.local/share/mise/shims:/home/vscode/.opam/default/bin:${containerEnv:PATH}",
+    "MISE_GLOBAL_CONFIG_FILE": "${containerWorkspaceFolder}/mise.toml"
+  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/DEVCONTAINER.md
+++ b/DEVCONTAINER.md
@@ -34,6 +34,22 @@ cat .devcontainer-image/Dockerfile mise.toml | sha256sum | cut -c1-12
 この方式により、**イメージの内容が変わったときだけタグが変わる**。
 コミットのたびにタグが変わる（コミットハッシュ方式の）問題を避けられる。
 
+## VS Code からのツール解決（remoteEnv の PATH 設定）
+
+mise によるツールの有効化（`mise activate`）はコンテナ内の `~/.bashrc` に書かれているため、
+**対話シェル（統合ターミナルなど）でしか効かない**。VS Code の拡張機能（Metals、Calva など）が
+LSP サーバーやツールを起動するプロセスは対話シェルを経由しないため、そのままでは
+java や clojure が見つからず LSP が動かない。
+
+このため `devcontainer.json` の `remoteEnv` で以下を設定している。
+
+- `PATH` に mise の shims（`~/.local/share/mise/shims`）と opam の bin（`~/.opam/default/bin`、dune 用）を追加
+  → シェルの種類に関係なく全ツールが解決できる
+- `MISE_GLOBAL_CONFIG_FILE` にリポジトリの `mise.toml` を指定
+  → shims がカレントディレクトリに依存せずバージョンを解決できる
+  （shims は実行時にカレントディレクトリから mise 設定を探すため、これがないと
+  ワークスペース外を起点とするプロセスから実行したときに失敗する）
+
 ## arm64（Apple Silicon など）での利用
 
 配布イメージは amd64 専用のため、arm64 マシンでは「コンテナーで再度開く」時の構成選択ダイアログで


### PR DESCRIPTION
## 変更している内容とその理由

### 問題

Dev Container内でVS CodeのLSP拡張(Metals、Calvaなど)が動作しない。

miseによるツール有効化は `~/.bashrc` の `mise activate` で行われるが、これは対話シェルでしか効かない。VS Codeが拡張機能に渡す環境変数はホームディレクトリを起点に採取され、miseはカレントディレクトリの `mise.toml` を見てPATHを注入する仕組みのため、採取結果にツールのPATHが一切含まれない。結果としてMetalsはjavaを、Calvaはclojureを見つけられない。

また、opam経由でインストールされる `dune` は対話シェルでも `opam env` を通さないと見えなかった。

### 修正

`devcontainer.json`(配布イメージ版・local-build版の両方)の `remoteEnv` で以下を設定する。

- `PATH` に miseの shims (`~/.local/share/mise/shims`) と opamの bin (`~/.opam/default/bin`) を追加
  - シェルの種類に関係なく全ツールが解決できるようになる
- `MISE_GLOBAL_CONFIG_FILE` にリポジトリの `mise.toml` を指定
  - shimsは実行時にカレントディレクトリからmise設定を探すため、これがないとワークスペース外(ホームなど)を起点とするプロセスからの実行に失敗する

仕組みの説明を `DEVCONTAINER.md` にも追記した。

### 検証

起動中のDev Containerコンテナ内で `remoteEnv` 相当の環境変数を与えて確認済み。

- ワークスペース内・ホームディレクトリのどちらを起点にしても `java` / `clojure` / `sbt` / `dune` が正しいバージョンで解決される
- shimsはビルド済み配布イメージに生成済みのため、**イメージの再ビルドは不要**(利用者はpullして「Reopen in Container」するだけ)

### 残課題(後続対応)

`haskell-language-server` と `ocamllsp` はそもそもイメージにインストールされていないため、PATHを直してもHaskell/OCamlのLSPは動かない。これらの追加は `mise.toml` / Dockerfileの変更とイメージ再ビルドが必要なため、別PRで対応する。

## チェックリスト

- [x] 変更内容に合理的な理由があることを上記セクションで説明した
- [x] [CONTRIBUTING.md](https://github.com/fp-matsuri/fp-in-scala-exercises/blob/main/CONTRIBUTING.md)の問題作成方針に沿って作成した
- [x] 不要な(自動生成)ファイルが含まれないように適切に `.gitignore` されている
- [ ] ~~[テストコードがある場合]~~ (言語コンテンツの変更なし)
- [ ] ~~[リンター/フォーマッターがある場合]~~ (言語コンテンツの変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)