### PR TITLE
OCaml版第7章 (parallelism) のコードを追加

### DIFF
--- a/fp-in-ocaml/answers/dune
+++ b/fp-in-ocaml/answers/dune
@@ -1,4 +1,5 @@
 (include_subdirs qualified)
 
 (library
- (name answers))
+ (name answers)
+ (libraries threads.posix))

--- a/fp-in-ocaml/answers/parallelism/par.ml
+++ b/fp-in-ocaml/answers/parallelism/par.ml
@@ -1,0 +1,288 @@
+(* 第7章 純粋関数型の並列処理
+
+   Scala 版では java.util.concurrent の [ExecutorService] と [Future] を利用するが、
+   OCaml の標準ライブラリには対応する機能がないため、[Thread] ベースの簡易な実装
+   ([Executor], [Future]) を自前で用意している。
+
+   OCaml 5 の systhreads (Thread) は同一ドメイン内ではランタイムロックを共有するため
+   並列には実行されない (並行実行のみ)。ただし本章の目的は並列計算を「記述」する
+   API の設計であり、そのセマンティクスは Thread でも表現できる。
+   真の並列実行が必要な場合は [Domain] や domainslib を利用する。
+
+   なお Exercise 7.3 (タイムアウトを考慮した map2) は Java の
+   [Future.get(timeout, unit)] という機構が前提であり、この簡易実装には
+   対応する機能がないため省略している。 *)
+
+(** 計算結果をあとから取得できる入れ物。[java.util.concurrent.Future] の簡易版。 *)
+module Future : sig
+  type 'a t
+
+  val completed : 'a -> 'a t
+  (** 完了済みの Future を作る。Scala 版の [UnitFuture] に相当。 *)
+
+  val get : 'a t -> 'a
+  (** 計算が完了するまでブロックして結果を取り出す。 計算が例外で終わっていた場合はその例外を送出する。 *)
+
+  val is_done : 'a t -> bool
+
+  val create : unit -> 'a t
+  (** 未完了の Future を作る。[Executor] が利用する内部 API。 *)
+
+  val deliver : 'a t -> ('a, exn) result -> unit
+  (** 結果を書き込み、待機中のスレッドを起こす。[Executor] が利用する内部 API。 *)
+end = struct
+  type 'a state = Pending | Resolved of ('a, exn) result
+  type 'a t = { mutex : Mutex.t; cond : Condition.t; mutable state : 'a state }
+
+  let create () =
+    { mutex = Mutex.create (); cond = Condition.create (); state = Pending }
+
+  let completed a =
+    {
+      mutex = Mutex.create ();
+      cond = Condition.create ();
+      state = Resolved (Ok a);
+    }
+
+  let deliver fut result =
+    Mutex.lock fut.mutex;
+    fut.state <- Resolved result;
+    (* [broadcast] で待機中のすべてのスレッドを起こす *)
+    Condition.broadcast fut.cond;
+    Mutex.unlock fut.mutex
+
+  let get fut =
+    Mutex.lock fut.mutex;
+    let rec wait () =
+      match fut.state with
+      (* [Condition.wait] はミューテックスを解放して通知を待ち、 起こされたら再度ロックを取得して戻ってくる *)
+      | Pending ->
+          Condition.wait fut.cond fut.mutex;
+          wait ()
+      | Resolved r -> r
+    in
+    let r = wait () in
+    Mutex.unlock fut.mutex;
+    match r with Ok a -> a | Error e -> raise e
+
+  let is_done fut =
+    Mutex.lock fut.mutex;
+    let d = match fut.state with Pending -> false | Resolved _ -> true in
+    Mutex.unlock fut.mutex;
+    d
+end
+
+(** 固定サイズのスレッドプール。[java.util.concurrent.ExecutorService] の簡易版。 *)
+module Executor : sig
+  type t
+
+  val make : int -> t
+  (** 指定した数のワーカースレッドを持つプールを作る *)
+
+  val submit : t -> (unit -> 'a) -> 'a Future.t
+  (** タスクをキューに追加し、結果を受け取るための Future を返す *)
+
+  val shutdown : t -> unit
+  (** キューに残ったタスクの完了を待ってすべてのワーカーを停止する *)
+end = struct
+  type t = {
+    mutex : Mutex.t;
+    cond : Condition.t;
+    tasks : (unit -> unit) Queue.t;
+    mutable stopped : bool;
+    mutable workers : Thread.t list;
+  }
+
+  let rec worker_loop pool =
+    Mutex.lock pool.mutex;
+    while Queue.is_empty pool.tasks && not pool.stopped do
+      Condition.wait pool.cond pool.mutex
+    done;
+    if Queue.is_empty pool.tasks then
+      (* 停止指示済みかつタスクなし: ワーカーを終了する *)
+      Mutex.unlock pool.mutex
+    else begin
+      let task = Queue.pop pool.tasks in
+      Mutex.unlock pool.mutex;
+      task ();
+      worker_loop pool
+    end
+
+  let make size =
+    let pool =
+      {
+        mutex = Mutex.create ();
+        cond = Condition.create ();
+        tasks = Queue.create ();
+        stopped = false;
+        workers = [];
+      }
+    in
+    pool.workers <- List.init size (fun _ -> Thread.create worker_loop pool);
+    pool
+
+  let submit pool f =
+    let future = Future.create () in
+    let task () =
+      let result = try Ok (f ()) with e -> Error e in
+      Future.deliver future result
+    in
+    Mutex.lock pool.mutex;
+    Queue.push task pool.tasks;
+    Condition.signal pool.cond;
+    Mutex.unlock pool.mutex;
+    future
+
+  let shutdown pool =
+    Mutex.lock pool.mutex;
+    pool.stopped <- true;
+    Condition.broadcast pool.cond;
+    Mutex.unlock pool.mutex;
+    List.iter Thread.join pool.workers
+end
+
+type 'a t = Executor.t -> 'a Future.t
+(** 並列計算の記述。[Executor.t] を受け取って [Future.t] を返す関数として表現する (Exercise 7.2 「Par
+    の表現を考えよ」の解答に相当)。 *)
+
+(** 並列計算を実際に実行して結果を取り出す *)
+let run (es : Executor.t) (pa : 'a t) : 'a = Future.get (pa es)
+
+(** 定数値をそのまま返す並列計算。[Executor] を利用せず、常に完了済みの Future を返す。 *)
+let unit (a : 'a) : 'a t = fun _ -> Future.completed a
+
+(* [map2] は [f] の適用自体を別スレッドで評価しない。並列性の制御は [fork] だけが
+   担うという設計方針のため。[f] の評価を別スレッドで行いたい場合は
+   [fork (lazy (map2 f a b))] とすればよい。 *)
+let map2 (f : 'a -> 'b -> 'c) (pa : 'a t) (pb : 'b t) : 'c t =
+ fun es ->
+  let fa = pa es in
+  let fb = pb es in
+  Future.completed (f (Future.get fa) (Future.get fb))
+
+(* もっとも素朴な [fork] の実装。ただし外側のタスクが内側のタスクの完了を待って
+   ブロックするため、1つの計算にワーカースレッドを2つ消費してしまう。
+   固定サイズのプールでは [fork] の入れ子がプールのサイズを超えるとデッドロックする。
+   この問題は本章の後半で議論される (Scala 版 Nonblocking.scala を参照)。 *)
+let fork (pa : 'a t Lazy.t) : 'a t =
+ fun es -> Executor.submit es (fun () -> run es (Lazy.force pa))
+
+(* Scala の名前渡し引数 (=> A) は OCaml では [Lazy.t] で表現する *)
+let lazy_unit (a : 'a Lazy.t) : 'a t = fork (lazy (unit (Lazy.force a)))
+
+(** [fork] と異なりワーカースレッドを消費せず、評価だけを [run] まで遅延する *)
+let delay (pa : 'a t Lazy.t) : 'a t = fun es -> Lazy.force pa es
+
+(** Exercise 7.4: [lazy_unit] を用いて、任意の関数 [f] を非同期に結果を評価する関数に変換する[async_f]を実装せよ。
+*)
+let async_f (f : 'a -> 'b) : 'a -> 'b t = fun a -> lazy_unit (lazy (f a))
+
+let map (f : 'a -> 'b) (pa : 'a t) : 'b t = map2 (fun a () -> f a) pa (unit ())
+let sort_par (p : int list t) : int list t = map (List.sort compare) p
+
+(** Exercise 7.5: Par のリストを1つの Par にまとめる[sequence]を実装せよ。
+
+    - [sequence_right]: リストを右からたどり、再帰のステップを [fork] で別スレッドに逃がす実装
+    - [sequence_balanced]: 配列を半分に分割して両側を並列に処理する実装
+    - [sequence]: [sequence_balanced] を利用したリスト向けのインターフェース *)
+
+(* 再帰のステップを [fork] するため末尾再帰に近い動きになるが、
+   右に深くネストした並列計算になる。リストを半分ずつに分割する
+   [sequence_balanced] のほうが効率がよい *)
+let rec sequence_right (ps : 'a t list) : 'a list t =
+  match ps with
+  | [] -> unit []
+  | h :: tl -> map2 List.cons h (fork (lazy (sequence_right tl)))
+
+(* 配列はリストと異なり半分への分割が効率的に行える *)
+let rec sequence_balanced (ps : 'a t array) : 'a array t =
+  match Array.length ps with
+  | 0 -> unit [||]
+  | 1 -> map (fun a -> [| a |]) ps.(0)
+  | n ->
+      let l = Array.sub ps 0 (n / 2) in
+      let r = Array.sub ps (n / 2) (n - (n / 2)) in
+      map2 Array.append (sequence_balanced l) (sequence_balanced r)
+
+let sequence (ps : 'a t list) : 'a list t =
+  ps |> Array.of_list |> sequence_balanced |> map Array.to_list
+
+(* リストの各要素への関数適用を並列に行う。1つの [fork] で包むことで、
+   [par_map] の呼び出し自体は即座に返る *)
+let par_map (f : 'a -> 'b) (ps : 'a list) : 'b list t =
+  fork (lazy (sequence (List.map (async_f f) ps)))
+
+(** Exercise 7.6: リストの要素の絞り込みを並列で行う[par_filter]を実装せよ。 *)
+let par_filter (p : 'a -> bool) (ps : 'a list) : 'a list t =
+  let pars = List.map (async_f (fun a -> if p a then [ a ] else [])) ps in
+  map List.concat (sequence pars)
+
+(** 2つの並列計算が同じ結果になるかを確認する *)
+let equal (es : Executor.t) (p1 : 'a t) (p2 : 'a t) : bool =
+  run es p1 = run es p2
+
+(* [cond] の結果を待ってから実行する側の計算を選ぶ *)
+let choice (cond : bool t) (if_true : 'a t) (if_false : 'a t) : 'a t =
+ fun es -> if run es cond then if_true es else if_false es
+
+(** Exercise 7.11: [n] の結果を添字としてリストから計算を選ぶ[choice_n]を実装せよ。
+    また、[choice_n]を用いて[choice_via_choice_n]を実装せよ。 *)
+
+let choice_n (n : int t) (choices : 'a t list) : 'a t =
+ fun es ->
+  let i = run es n in
+  (List.nth choices i) es
+
+let choice_via_choice_n (cond : bool t) (if_true : 'a t) (if_false : 'a t) :
+    'a t =
+  choice_n (map (fun b -> if b then 0 else 1) cond) [ if_true; if_false ]
+
+(** Exercise 7.12: [key] の結果をキーとして連想リストから計算を選ぶ[choice_map]を実装せよ。 (Scala 版の [Map]
+    の代わりに連想リストを利用する) *)
+let choice_map (key : 'k t) (choices : ('k * 'v t) list) : 'v t =
+ fun es ->
+  let k = run es key in
+  (List.assoc k choices) es
+
+(** Exercise 7.13: [choice], [choice_n], [choice_map] を一般化した[chooser]を実装せよ。
+    また、[chooser]を用いて[choice_via_chooser], [choice_n_via_chooser]を実装せよ。 *)
+
+let chooser (f : 'a -> 'b t) (pa : 'a t) : 'b t =
+ fun es ->
+  let a = run es pa in
+  (f a) es
+
+let choice_via_chooser (cond : bool t) (if_true : 'a t) (if_false : 'a t) : 'a t
+    =
+  chooser (fun b -> if b then if_true else if_false) cond
+
+let choice_n_via_chooser (n : int t) (choices : 'a t list) : 'a t =
+  chooser (List.nth choices) n
+
+(* [chooser] は一般に flatMap や bind と呼ばれる *)
+let flat_map (f : 'a -> 'b t) (pa : 'a t) : 'b t = chooser f pa
+
+(** Exercise 7.14: 入れ子になった並列計算を平坦化する[join]を実装せよ。
+    また、[flat_map]を用いた[join_via_flat_map]、[join]を用いた [flat_map_via_join]も実装せよ。 *)
+
+let join (ppa : 'a t t) : 'a t =
+ fun es ->
+  let pa = run es ppa in
+  pa es
+
+let join_via_flat_map (ppa : 'a t t) : 'a t = flat_map Fun.id ppa
+let flat_map_via_join (f : 'a -> 'b t) (pa : 'a t) : 'b t = join (map f pa)
+
+module Examples = struct
+  (* 本章冒頭の例: 分割統治による合計。
+     配列 ([Array]) はリストと異なり、半分への分割が効率的に行える。
+     この時点ではまだ並列化されていないことに注意。 *)
+  let rec sum (ints : int array) : int =
+    if Array.length ints <= 1 then if Array.length ints = 0 then 0 else ints.(0)
+    else begin
+      let mid = Array.length ints / 2 in
+      let l = Array.sub ints 0 mid in
+      let r = Array.sub ints mid (Array.length ints - mid) in
+      sum l + sum r
+    end
+end

--- a/fp-in-ocaml/exercises/dune
+++ b/fp-in-ocaml/exercises/dune
@@ -2,5 +2,6 @@
 
 (library
  (name exercises)
+ (libraries threads.posix)
  (flags
   (:standard -w -unused-rec-flag)))

--- a/fp-in-ocaml/exercises/parallelism/par.ml
+++ b/fp-in-ocaml/exercises/parallelism/par.ml
@@ -1,0 +1,265 @@
+(* 第7章 純粋関数型の並列処理
+
+   Scala 版では java.util.concurrent の [ExecutorService] と [Future] を利用するが、
+   OCaml の標準ライブラリには対応する機能がないため、[Thread] ベースの簡易な実装
+   ([Executor], [Future]) を自前で用意している。
+
+   OCaml 5 の systhreads (Thread) は同一ドメイン内ではランタイムロックを共有するため
+   並列には実行されない (並行実行のみ)。ただし本章の目的は並列計算を「記述」する
+   API の設計であり、そのセマンティクスは Thread でも表現できる。
+   真の並列実行が必要な場合は [Domain] や domainslib を利用する。
+
+   なお Exercise 7.3 (タイムアウトを考慮した map2) は Java の
+   [Future.get(timeout, unit)] という機構が前提であり、この簡易実装には
+   対応する機能がないため省略している。 *)
+
+(** 計算結果をあとから取得できる入れ物。[java.util.concurrent.Future] の簡易版。 *)
+module Future : sig
+  type 'a t
+
+  val completed : 'a -> 'a t
+  (** 完了済みの Future を作る。Scala 版の [UnitFuture] に相当。 *)
+
+  val get : 'a t -> 'a
+  (** 計算が完了するまでブロックして結果を取り出す。 計算が例外で終わっていた場合はその例外を送出する。 *)
+
+  val is_done : 'a t -> bool
+
+  val create : unit -> 'a t
+  (** 未完了の Future を作る。[Executor] が利用する内部 API。 *)
+
+  val deliver : 'a t -> ('a, exn) result -> unit
+  (** 結果を書き込み、待機中のスレッドを起こす。[Executor] が利用する内部 API。 *)
+end = struct
+  type 'a state = Pending | Resolved of ('a, exn) result
+  type 'a t = { mutex : Mutex.t; cond : Condition.t; mutable state : 'a state }
+
+  let create () =
+    { mutex = Mutex.create (); cond = Condition.create (); state = Pending }
+
+  let completed a =
+    {
+      mutex = Mutex.create ();
+      cond = Condition.create ();
+      state = Resolved (Ok a);
+    }
+
+  let deliver fut result =
+    Mutex.lock fut.mutex;
+    fut.state <- Resolved result;
+    (* [broadcast] で待機中のすべてのスレッドを起こす *)
+    Condition.broadcast fut.cond;
+    Mutex.unlock fut.mutex
+
+  let get fut =
+    Mutex.lock fut.mutex;
+    let rec wait () =
+      match fut.state with
+      (* [Condition.wait] はミューテックスを解放して通知を待ち、 起こされたら再度ロックを取得して戻ってくる *)
+      | Pending ->
+          Condition.wait fut.cond fut.mutex;
+          wait ()
+      | Resolved r -> r
+    in
+    let r = wait () in
+    Mutex.unlock fut.mutex;
+    match r with Ok a -> a | Error e -> raise e
+
+  let is_done fut =
+    Mutex.lock fut.mutex;
+    let d = match fut.state with Pending -> false | Resolved _ -> true in
+    Mutex.unlock fut.mutex;
+    d
+end
+
+(** 固定サイズのスレッドプール。[java.util.concurrent.ExecutorService] の簡易版。 *)
+module Executor : sig
+  type t
+
+  val make : int -> t
+  (** 指定した数のワーカースレッドを持つプールを作る *)
+
+  val submit : t -> (unit -> 'a) -> 'a Future.t
+  (** タスクをキューに追加し、結果を受け取るための Future を返す *)
+
+  val shutdown : t -> unit
+  (** キューに残ったタスクの完了を待ってすべてのワーカーを停止する *)
+end = struct
+  type t = {
+    mutex : Mutex.t;
+    cond : Condition.t;
+    tasks : (unit -> unit) Queue.t;
+    mutable stopped : bool;
+    mutable workers : Thread.t list;
+  }
+
+  let rec worker_loop pool =
+    Mutex.lock pool.mutex;
+    while Queue.is_empty pool.tasks && not pool.stopped do
+      Condition.wait pool.cond pool.mutex
+    done;
+    if Queue.is_empty pool.tasks then
+      (* 停止指示済みかつタスクなし: ワーカーを終了する *)
+      Mutex.unlock pool.mutex
+    else begin
+      let task = Queue.pop pool.tasks in
+      Mutex.unlock pool.mutex;
+      task ();
+      worker_loop pool
+    end
+
+  let make size =
+    let pool =
+      {
+        mutex = Mutex.create ();
+        cond = Condition.create ();
+        tasks = Queue.create ();
+        stopped = false;
+        workers = [];
+      }
+    in
+    pool.workers <- List.init size (fun _ -> Thread.create worker_loop pool);
+    pool
+
+  let submit pool f =
+    let future = Future.create () in
+    let task () =
+      let result = try Ok (f ()) with e -> Error e in
+      Future.deliver future result
+    in
+    Mutex.lock pool.mutex;
+    Queue.push task pool.tasks;
+    Condition.signal pool.cond;
+    Mutex.unlock pool.mutex;
+    future
+
+  let shutdown pool =
+    Mutex.lock pool.mutex;
+    pool.stopped <- true;
+    Condition.broadcast pool.cond;
+    Mutex.unlock pool.mutex;
+    List.iter Thread.join pool.workers
+end
+
+type 'a t = Executor.t -> 'a Future.t
+(** 並列計算の記述。[Executor.t] を受け取って [Future.t] を返す関数として表現する (Exercise 7.2 「Par
+    の表現を考えよ」の解答に相当)。 *)
+
+(** 並列計算を実際に実行して結果を取り出す *)
+let run (es : Executor.t) (pa : 'a t) : 'a = Future.get (pa es)
+
+(** 定数値をそのまま返す並列計算。[Executor] を利用せず、常に完了済みの Future を返す。 *)
+let unit (a : 'a) : 'a t = fun _ -> Future.completed a
+
+(* [map2] は [f] の適用自体を別スレッドで評価しない。並列性の制御は [fork] だけが
+   担うという設計方針のため。[f] の評価を別スレッドで行いたい場合は
+   [fork (lazy (map2 f a b))] とすればよい。 *)
+let map2 (f : 'a -> 'b -> 'c) (pa : 'a t) (pb : 'b t) : 'c t =
+ fun es ->
+  let fa = pa es in
+  let fb = pb es in
+  Future.completed (f (Future.get fa) (Future.get fb))
+
+(* もっとも素朴な [fork] の実装。ただし外側のタスクが内側のタスクの完了を待って
+   ブロックするため、1つの計算にワーカースレッドを2つ消費してしまう。
+   固定サイズのプールでは [fork] の入れ子がプールのサイズを超えるとデッドロックする。
+   この問題は本章の後半で議論される (Scala 版 Nonblocking.scala を参照)。 *)
+let fork (pa : 'a t Lazy.t) : 'a t =
+ fun es -> Executor.submit es (fun () -> run es (Lazy.force pa))
+
+(* Scala の名前渡し引数 (=> A) は OCaml では [Lazy.t] で表現する *)
+let lazy_unit (a : 'a Lazy.t) : 'a t = fork (lazy (unit (Lazy.force a)))
+
+(** [fork] と異なりワーカースレッドを消費せず、評価だけを [run] まで遅延する *)
+let delay (pa : 'a t Lazy.t) : 'a t = fun es -> Lazy.force pa es
+
+(** Exercise 7.4: [lazy_unit] を用いて、任意の関数 [f] を非同期に結果を評価する関数に変換する[async_f]を実装せよ。
+*)
+let async_f (_f : 'a -> 'b) : 'a -> 'b t = failwith "Not implemented"
+
+let map (f : 'a -> 'b) (pa : 'a t) : 'b t = map2 (fun a () -> f a) pa (unit ())
+let sort_par (p : int list t) : int list t = map (List.sort compare) p
+
+(** Exercise 7.5: Par のリストを1つの Par にまとめる[sequence]を実装せよ。
+
+    - [sequence_right]: リストを右からたどり、再帰のステップを [fork] で別スレッドに逃がす実装
+    - [sequence_balanced]: 配列を半分に分割して両側を並列に処理する実装
+    - [sequence]: [sequence_balanced] を利用したリスト向けのインターフェース *)
+
+let rec sequence_right (_ps : 'a t list) : 'a list t =
+  failwith "Not implemented"
+
+let rec sequence_balanced (_ps : 'a t array) : 'a array t =
+  failwith "Not implemented"
+
+let sequence (_ps : 'a t list) : 'a list t = failwith "Not implemented"
+
+(* リストの各要素への関数適用を並列に行う。1つの [fork] で包むことで、
+   [par_map] の呼び出し自体は即座に返る *)
+let par_map (f : 'a -> 'b) (ps : 'a list) : 'b list t =
+  fork (lazy (sequence (List.map (async_f f) ps)))
+
+(** Exercise 7.6: リストの要素の絞り込みを並列で行う[par_filter]を実装せよ。 *)
+let par_filter (_p : 'a -> bool) (_ps : 'a list) : 'a list t =
+  failwith "Not implemented"
+
+(** 2つの並列計算が同じ結果になるかを確認する *)
+let equal (es : Executor.t) (p1 : 'a t) (p2 : 'a t) : bool =
+  run es p1 = run es p2
+
+(* [cond] の結果を待ってから実行する側の計算を選ぶ *)
+let choice (cond : bool t) (if_true : 'a t) (if_false : 'a t) : 'a t =
+ fun es -> if run es cond then if_true es else if_false es
+
+(** Exercise 7.11: [n] の結果を添字としてリストから計算を選ぶ[choice_n]を実装せよ。
+    また、[choice_n]を用いて[choice_via_choice_n]を実装せよ。 *)
+
+let choice_n (_n : int t) (_choices : 'a t list) : 'a t =
+  failwith "Not implemented"
+
+let choice_via_choice_n (_cond : bool t) (_if_true : 'a t) (_if_false : 'a t) :
+    'a t =
+  failwith "Not implemented"
+
+(** Exercise 7.12: [key] の結果をキーとして連想リストから計算を選ぶ[choice_map]を実装せよ。 (Scala 版の [Map]
+    の代わりに連想リストを利用する) *)
+let choice_map (_key : 'k t) (_choices : ('k * 'v t) list) : 'v t =
+  failwith "Not implemented"
+
+(** Exercise 7.13: [choice], [choice_n], [choice_map] を一般化した[chooser]を実装せよ。
+    また、[chooser]を用いて[choice_via_chooser], [choice_n_via_chooser]を実装せよ。 *)
+
+let chooser (_f : 'a -> 'b t) (_pa : 'a t) : 'b t = failwith "Not implemented"
+
+let choice_via_chooser (_cond : bool t) (_if_true : 'a t) (_if_false : 'a t) :
+    'a t =
+  failwith "Not implemented"
+
+let choice_n_via_chooser (_n : int t) (_choices : 'a t list) : 'a t =
+  failwith "Not implemented"
+
+(* [chooser] は一般に flatMap や bind と呼ばれる *)
+let flat_map (f : 'a -> 'b t) (pa : 'a t) : 'b t = chooser f pa
+
+(** Exercise 7.14: 入れ子になった並列計算を平坦化する[join]を実装せよ。
+    また、[flat_map]を用いた[join_via_flat_map]、[join]を用いた [flat_map_via_join]も実装せよ。 *)
+
+let join (_ppa : 'a t t) : 'a t = failwith "Not implemented"
+let join_via_flat_map (_ppa : 'a t t) : 'a t = failwith "Not implemented"
+
+let flat_map_via_join (_f : 'a -> 'b t) (_pa : 'a t) : 'b t =
+  failwith "Not implemented"
+
+module Examples = struct
+  (* 本章冒頭の例: 分割統治による合計。
+     配列 ([Array]) はリストと異なり、半分への分割が効率的に行える。
+     この時点ではまだ並列化されていないことに注意。 *)
+  let rec sum (ints : int array) : int =
+    if Array.length ints <= 1 then if Array.length ints = 0 then 0 else ints.(0)
+    else begin
+      let mid = Array.length ints / 2 in
+      let l = Array.sub ints 0 mid in
+      let r = Array.sub ints mid (Array.length ints - mid) in
+      sum l + sum r
+    end
+end

--- a/fp-in-ocaml/test/dune
+++ b/fp-in-ocaml/test/dune
@@ -23,3 +23,9 @@
  (tests
   (names rng_test monad_test candy_test)
   (libraries alcotest exercises answers)))
+
+(subdir
+ parallelism
+ (tests
+  (names par_test)
+  (libraries alcotest exercises answers)))

--- a/fp-in-ocaml/test/parallelism/par_test.ml
+++ b/fp-in-ocaml/test/parallelism/par_test.ml
@@ -1,0 +1,220 @@
+(* exercises のPar実装を検証するテスト。
+   [open Exercises]を[open Answers]に差し替えれば解答例の動作確認になる。
+
+open Answers
+*)
+open Exercises
+module P = Parallelism.Par
+
+(* fork の入れ子がデッドロックしない程度に十分な数のワーカーを用意する。
+   固定サイズプールと fork の組み合わせによるデッドロックは本章の主題の1つ
+   (exercises/parallelism/par.ml の [fork] のコメントを参照)。 *)
+let with_pool f =
+  let es = P.Executor.make 16 in
+  Fun.protect ~finally:(fun () -> P.Executor.shutdown es) (fun () -> f es)
+
+let case n f = Alcotest.test_case n `Quick f
+
+let test_unit_run () =
+  with_pool @@ fun es -> Alcotest.(check int) "unit 1" 1 (P.run es (P.unit 1))
+
+let test_map2 () =
+  with_pool @@ fun es ->
+  Alcotest.(check int) "1 + 2" 3 (P.run es (P.map2 ( + ) (P.unit 1) (P.unit 2)))
+
+let test_fork () =
+  with_pool @@ fun es ->
+  Alcotest.(check int) "forked" 42 (P.run es (P.fork (lazy (P.unit 42))))
+
+let test_lazy_unit_is_lazy () =
+  with_pool @@ fun es ->
+  let evaluated = ref false in
+  let p =
+    P.lazy_unit
+      (lazy
+        (evaluated := true;
+         42))
+  in
+  Alcotest.(check bool) "not evaluated before run" false !evaluated;
+  Alcotest.(check int) "value" 42 (P.run es p);
+  Alcotest.(check bool) "evaluated after run" true !evaluated
+
+let test_async_f () =
+  with_pool @@ fun es ->
+  Alcotest.(check int) "succ" 42 (P.run es (P.async_f succ 41))
+
+let test_map () =
+  with_pool @@ fun es ->
+  Alcotest.(check string)
+    "map string_of_int" "42"
+    (P.run es (P.map string_of_int (P.unit 42)))
+
+let test_sort_par () =
+  with_pool @@ fun es ->
+  Alcotest.(check (list int))
+    "sorted" [ 1; 2; 3 ]
+    (P.run es (P.sort_par (P.unit [ 3; 1; 2 ])))
+
+let test_sequence_right () =
+  with_pool @@ fun es ->
+  Alcotest.(check (list int))
+    "sequence_right" [ 1; 2; 3 ]
+    (P.run es (P.sequence_right [ P.unit 1; P.unit 2; P.unit 3 ]))
+
+let test_sequence_balanced () =
+  with_pool @@ fun es ->
+  Alcotest.(check (array int))
+    "sequence_balanced" [| 1; 2; 3; 4; 5 |]
+    (P.run es (P.sequence_balanced (Array.init 5 (fun i -> P.unit (succ i)))));
+  Alcotest.(check (array int))
+    "empty" [||]
+    (P.run es (P.sequence_balanced [||]))
+
+let test_sequence () =
+  with_pool @@ fun es ->
+  Alcotest.(check (list int))
+    "sequence" [ 1; 2; 3 ]
+    (P.run es (P.sequence [ P.unit 1; P.unit 2; P.unit 3 ]));
+  Alcotest.(check (list int)) "empty" [] (P.run es (P.sequence []))
+
+let test_par_map () =
+  with_pool @@ fun es ->
+  Alcotest.(check (list int))
+    "squares" [ 1; 4; 9; 16 ]
+    (P.run es (P.par_map (fun x -> x * x) [ 1; 2; 3; 4 ]))
+
+let test_par_filter () =
+  with_pool @@ fun es ->
+  Alcotest.(check (list int))
+    "evens" [ 2; 4; 6; 8; 10 ]
+    (P.run es
+       (P.par_filter (fun x -> x mod 2 = 0) [ 1; 2; 3; 4; 5; 6; 7; 8; 9; 10 ]))
+
+let test_equal () =
+  with_pool @@ fun es ->
+  Alcotest.(check bool)
+    "map succ = unit 2" true
+    (P.equal es (P.map succ (P.unit 1)) (P.unit 2))
+
+let test_choice () =
+  with_pool @@ fun es ->
+  Alcotest.(check string)
+    "true" "t"
+    (P.run es (P.choice (P.unit true) (P.unit "t") (P.unit "f")));
+  Alcotest.(check string)
+    "false" "f"
+    (P.run es (P.choice (P.unit false) (P.unit "t") (P.unit "f")))
+
+let choices = [ P.unit "a"; P.unit "b"; P.unit "c" ]
+
+let test_choice_n () =
+  with_pool @@ fun es ->
+  Alcotest.(check string)
+    "index 1" "b"
+    (P.run es (P.choice_n (P.unit 1) choices))
+
+let test_choice_via_choice_n () =
+  with_pool @@ fun es ->
+  Alcotest.(check string)
+    "true" "t"
+    (P.run es (P.choice_via_choice_n (P.unit true) (P.unit "t") (P.unit "f")));
+  Alcotest.(check string)
+    "false" "f"
+    (P.run es (P.choice_via_choice_n (P.unit false) (P.unit "t") (P.unit "f")))
+
+let test_choice_map () =
+  with_pool @@ fun es ->
+  let m = [ ("a", P.unit 1); ("b", P.unit 2) ] in
+  Alcotest.(check int) "key b" 2 (P.run es (P.choice_map (P.unit "b") m))
+
+let test_chooser () =
+  with_pool @@ fun es ->
+  Alcotest.(check int)
+    "x * 10" 20
+    (P.run es (P.chooser (fun x -> P.unit (x * 10)) (P.unit 2)))
+
+let test_choice_via_chooser () =
+  with_pool @@ fun es ->
+  Alcotest.(check string)
+    "true" "t"
+    (P.run es (P.choice_via_chooser (P.unit true) (P.unit "t") (P.unit "f")));
+  Alcotest.(check string)
+    "false" "f"
+    (P.run es (P.choice_via_chooser (P.unit false) (P.unit "t") (P.unit "f")))
+
+let test_choice_n_via_chooser () =
+  with_pool @@ fun es ->
+  Alcotest.(check string)
+    "index 2" "c"
+    (P.run es (P.choice_n_via_chooser (P.unit 2) choices))
+
+let test_flat_map () =
+  with_pool @@ fun es ->
+  Alcotest.(check int)
+    "flat_map" 42
+    (P.run es (P.flat_map (fun x -> P.lazy_unit (lazy (x * 2))) (P.unit 21)))
+
+let test_join () =
+  with_pool @@ fun es ->
+  Alcotest.(check int) "join" 42 (P.run es (P.join (P.unit (P.unit 42))))
+
+let test_join_via_flat_map () =
+  with_pool @@ fun es ->
+  Alcotest.(check int)
+    "join_via_flat_map" 42
+    (P.run es (P.join_via_flat_map (P.unit (P.unit 42))))
+
+let test_flat_map_via_join () =
+  with_pool @@ fun es ->
+  Alcotest.(check int)
+    "flat_map_via_join" 42
+    (P.run es (P.flat_map_via_join (fun x -> P.unit (x * 2)) (P.unit 21)))
+
+let test_examples_sum () =
+  Alcotest.(check int) "sum" 15 (P.Examples.sum [| 1; 2; 3; 4; 5 |]);
+  Alcotest.(check int) "empty" 0 (P.Examples.sum [||])
+
+let () =
+  Alcotest.run "parallelism.Par"
+    [
+      ( "Par.basic",
+        [
+          case "unit/run" test_unit_run;
+          case "map2" test_map2;
+          case "fork" test_fork;
+          case "lazy_unit is lazy" test_lazy_unit_is_lazy;
+          case "map" test_map;
+          case "sort_par" test_sort_par;
+          case "equal" test_equal;
+          case "choice" test_choice;
+        ] );
+      ("Par.async_f", [ case "async_f" test_async_f ]);
+      ( "Par.sequence",
+        [
+          case "sequence_right" test_sequence_right;
+          case "sequence_balanced" test_sequence_balanced;
+          case "sequence" test_sequence;
+          case "par_map" test_par_map;
+        ] );
+      ("Par.par_filter", [ case "par_filter" test_par_filter ]);
+      ( "Par.choice_n",
+        [
+          case "choice_n" test_choice_n;
+          case "choice_via_choice_n" test_choice_via_choice_n;
+        ] );
+      ("Par.choice_map", [ case "choice_map" test_choice_map ]);
+      ( "Par.chooser",
+        [
+          case "chooser" test_chooser;
+          case "choice_via_chooser" test_choice_via_chooser;
+          case "choice_n_via_chooser" test_choice_n_via_chooser;
+          case "flat_map" test_flat_map;
+        ] );
+      ( "Par.join",
+        [
+          case "join" test_join;
+          case "join_via_flat_map" test_join_via_flat_map;
+          case "flat_map_via_join" test_flat_map_via_join;
+        ] );
+      ("Par.examples", [ case "sum" test_examples_sum ]);
+    ]


### PR DESCRIPTION
## 概要

FP in Scala 第7章「純粋関数型の並列処理」を OCaml に移植しました。

- `exercises/parallelism/par.ml` — 演習問題 (Exercise 7.4, 7.5, 7.6, 7.11〜7.14 をスタブ化)
- `answers/parallelism/par.ml` — 解答例
- `test/parallelism/par_test.ml` — alcotest によるテスト (25件)

## 設計上のポイント

- Scala 版が利用する `java.util.concurrent` の `ExecutorService` / `Future` に相当する機能が OCaml 標準ライブラリにないため、`Thread` + `Mutex` + `Condition` による固定サイズスレッドプール (`Executor`) とブロッキング `Future` を自前実装して章の前提を再現しています
- `Par` の表現は Scala 版と同じく `Executor.t -> 'a Future.t` (Exercise 7.2 の解答に相当)
- Scala の名前渡し引数 (`=> A`) は `Lazy.t` で表現
- Exercise 7.3 (タイムアウトを考慮した `map2`) は Java の `Future.get(timeout, unit)` 機構が前提のため、CONTRIBUTING の方針に沿って説明コメント付きで省略しています
- `fork` の入れ子と固定サイズプールによるデッドロック問題 (本章後半の主題) はコメントで解説し、テストでは十分なワーカー数 (16) を確保しています
- Nonblocking (Actor ベース) 実装の移植は本PRのスコープ外としています

## 確認

- `dune build` / `dune build @fmt` パス
- `dune exec test/parallelism/par_test.exe`: exercises 対象で 16件 FAIL (スタブの想定挙動)
- テストの `open Exercises` を `open Answers` に差し替えると 25件全パスすることを確認済み

https://claude.ai/code/session_01FyQP62cfbHAP4y1gy77Lap